### PR TITLE
Fix/terminal linux env term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,10 +123,17 @@ winapi = { version = "0.3", features = [
 ] }
 windows = { version = "0.61", features = [
     "Win32",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System",
     "Win32_System_Diagnostics",
-    "Win32_System_Threading",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Environment",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+    "Win32_UI_Shell",
 ] }
 winreg = "0.11"
 windows-service = "0.6"

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -603,6 +603,17 @@ pub fn core_main() -> Option<Vec<String>> {
             #[cfg(feature = "hwcodec")]
             crate::ipc::hwcodec_process();
             return None;
+        } else if args[0] == "--terminal-helper" {
+            // Terminal helper process - runs as user to create ConPTY
+            // This is needed because ConPTY has compatibility issues with CreateProcessAsUserW
+            #[cfg(target_os = "windows")]
+            {
+                let helper_args: Vec<String> = args[1..].to_vec();
+                if let Err(e) = crate::server::terminal_helper::run_terminal_helper(&helper_args) {
+                    log::error!("Terminal helper failed: {}", e);
+                }
+            }
+            return None;
         } else if args[0] == "--cm" {
             // call connection manager to establish connections
             // meanwhile, return true to call flutter window to show control panel

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -399,9 +399,9 @@ fn get_all_term_values(uid: &str) -> Vec<String> {
         return Vec::new();
     };
 
-    // Build regex pattern to match shell processes
-    // Pattern: match process name at start, after '/', or after space, followed by space or end
-    // e.g., "bash", "/bin/bash", "/usr/bin/zsh -l"
+    // Build regex pattern to match shell processes using only argv[0] (the executable path)
+    // Pattern: match process name at start or after '/', followed by space or end
+    // e.g., "bash", "/bin/bash", "/usr/bin/zsh"
     let shell_pattern = SHELL_PROCESSES
         .iter()
         .map(|p| format!(r"(^|/){p}(\s|$)"))

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -35,13 +35,20 @@ static mut UNMODIFIED: bool = true;
 const INVALID_TERM_VALUES: [&str; 3] = ["", "unknown", "dumb"];
 const SHELL_PROCESSES: [&str; 4] = ["bash", "zsh", "fish", "sh"];
 
+// Terminal type constants
+const TERM_XTERM_256COLOR: &str = "xterm-256color";
+const TERM_SCREEN_256COLOR: &str = "screen-256color";
+const TERM_XTERM: &str = "xterm";
+
 lazy_static::lazy_static! {
     pub static ref IS_X11: bool = hbb_common::platform::linux::is_x11_or_headless();
+    // Cache for TERM value - once TERM_XTERM_256COLOR is found, reuse it directly
+    static ref CACHED_TERM: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
     static ref DATABASE_XTERM_256COLOR: Option<Database> = {
-        match Database::from_name("xterm-256color") {
+        match Database::from_name(TERM_XTERM_256COLOR) {
             Ok(database) => Some(database),
             Err(err) => {
-                log::error!("Failed to initialize xterm-256color database: {}", err);
+                log::error!("Failed to initialize {} database: {}", TERM_XTERM_256COLOR, err);
                 None
             }
         }
@@ -310,12 +317,12 @@ fn start_uinput_service() {
 /// modern features required by many applications.
 fn suggest_best_term() -> String {
     if is_running_in_tmux() || is_running_in_screen() {
-        return "screen-256color".to_string();
+        return TERM_SCREEN_256COLOR.to_string();
     }
-    if term_supports_256_colors("xterm-256color") {
-        return "xterm-256color".to_string();
+    if term_supports_256_colors(TERM_XTERM_256COLOR) {
+        return TERM_XTERM_256COLOR.to_string();
     }
-    "xterm".to_string()
+    TERM_XTERM.to_string()
 }
 
 fn is_running_in_tmux() -> bool {
@@ -332,7 +339,7 @@ fn supports_256_colors(db: &Database) -> bool {
 
 fn term_supports_256_colors(term: &str) -> bool {
     match term {
-        "xterm-256color" => DATABASE_XTERM_256COLOR
+        TERM_XTERM_256COLOR => DATABASE_XTERM_256COLOR
             .as_ref()
             .map_or(false, |db| supports_256_colors(db)),
         _ => Database::from_name(term).map_or(false, |db| supports_256_colors(&db)),
@@ -340,25 +347,140 @@ fn term_supports_256_colors(term: &str) -> bool {
 }
 
 fn get_cur_term(uid: &str) -> Option<String> {
+    // Check cache first - if TERM_XTERM_256COLOR was found before, reuse it
+    if let Ok(cache) = CACHED_TERM.lock() {
+        if let Some(ref cached) = *cache {
+            if cached == TERM_XTERM_256COLOR {
+                return Some(cached.clone());
+            }
+        }
+    }
+
     if uid.is_empty() {
         return None;
     }
 
+    // Check current process environment
     if let Ok(term) = std::env::var("TERM") {
-        if !INVALID_TERM_VALUES.contains(&term.as_str()) {
+        if term == TERM_XTERM_256COLOR {
+            if let Ok(mut cache) = CACHED_TERM.lock() {
+                *cache = Some(term.clone());
+            }
             return Some(term);
         }
     }
 
-    for proc in SHELL_PROCESSES {
-        // Construct a regex pattern to match either the process name followed by '$' or 'bin/' followed by the process name.
-        let term = get_env("TERM", uid, &format!("{}$|bin/{}", proc, proc));
-        if !INVALID_TERM_VALUES.contains(&term.as_str()) {
-            return Some(term);
+    // Collect all TERM values from shell processes, looking for TERM_XTERM_256COLOR
+    let terms = get_all_term_values(uid);
+
+    // Prefer TERM_XTERM_256COLOR
+    if terms.iter().any(|t| t == TERM_XTERM_256COLOR) {
+        if let Ok(mut cache) = CACHED_TERM.lock() {
+            *cache = Some(TERM_XTERM_256COLOR.to_string());
+        }
+        return Some(TERM_XTERM_256COLOR.to_string());
+    }
+
+    // Return first valid TERM if no TERM_XTERM_256COLOR found
+    let fallback = terms.into_iter().next();
+    if let Some(ref term) = fallback {
+        log::debug!(
+            "TERM_XTERM_256COLOR not found, using fallback TERM: {}",
+            term
+        );
+    }
+    fallback
+}
+
+/// Get all TERM values from shell processes (bash, zsh, fish, sh).
+/// Returns a Vec of unique, valid TERM values.
+fn get_all_term_values(uid: &str) -> Vec<String> {
+    let Ok(uid_num) = uid.parse::<u32>() else {
+        return Vec::new();
+    };
+
+    // Build regex pattern to match shell processes
+    // Pattern: match process name at start, after '/', or after space, followed by space or end
+    // e.g., "bash", "/bin/bash", "/usr/bin/zsh -l"
+    let shell_pattern = SHELL_PROCESSES
+        .iter()
+        .map(|p| format!(r"(^|/){p}(\s|$)"))
+        .collect::<Vec<_>>()
+        .join("|");
+    let Ok(re) = Regex::new(&shell_pattern) else {
+        return Vec::new();
+    };
+
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+
+    let mut terms = Vec::new();
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(pid_str) = file_name.to_str() else {
+            continue;
+        };
+        if !pid_str.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+
+        let proc_path = entry.path();
+
+        // Check if process belongs to the specified uid
+        if let Ok(meta) = std::fs::metadata(&proc_path) {
+            use std::os::unix::fs::MetadataExt;
+            if meta.uid() != uid_num {
+                continue;
+            }
+        } else {
+            continue;
+        }
+
+        // Check cmdline matches process pattern
+        // /proc/<pid>/cmdline is a sequence of null-terminated strings; the first
+        // one (argv[0]) is the executable path. Match the regex only against that
+        // to avoid false positives from arguments (e.g., "python /path/to/bash-script.py").
+        let cmdline_path = proc_path.join("cmdline");
+        let Ok(cmdline) = std::fs::read(&cmdline_path) else {
+            continue;
+        };
+        let exe_end = cmdline.iter().position(|&b| b == 0).unwrap_or(cmdline.len());
+        let exe_str = String::from_utf8_lossy(&cmdline[..exe_end]);
+        if !re.is_match(&exe_str) {
+            continue;
+        }
+
+        // Read environ and extract TERM
+        let environ_path = proc_path.join("environ");
+        let Ok(environ) = std::fs::read(&environ_path) else {
+            continue;
+        };
+
+        for part in environ.split(|&b| b == 0) {
+            if part.is_empty() {
+                continue;
+            }
+            if let Some(eq) = part.iter().position(|&b| b == b'=') {
+                let key_bytes = &part[..eq];
+                if key_bytes == b"TERM" {
+                    let val_bytes = &part[eq + 1..];
+                    let term = String::from_utf8_lossy(val_bytes).into_owned();
+                    if !INVALID_TERM_VALUES.contains(&term.as_str()) && !terms.contains(&term) {
+                        // Early return if we found the preferred term
+                        if term == TERM_XTERM_256COLOR {
+                            return vec![term];
+                        }
+                        terms.push(term);
+                    }
+                    break;
+                }
+            }
         }
     }
 
-    None
+    terms
 }
 
 #[inline]

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,8 @@ use video_service::VideoSource;
 use crate::ipc::Data;
 
 pub mod audio_service;
+#[cfg(target_os = "windows")]
+pub mod terminal_helper;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod terminal_service;
 cfg_if::cfg_if! {

--- a/src/server/terminal_helper.rs
+++ b/src/server/terminal_helper.rs
@@ -1,0 +1,347 @@
+//! Terminal Helper Process
+//!
+//! This module implements a helper process that runs as the logged-in user and creates
+//! the ConPTY + Shell. This is necessary because ConPTY has compatibility issues with
+//! CreateProcessAsUserW when the ConPTY is created by a different user (SYSTEM service).
+//!
+//! Architecture:
+//! ```
+//! SYSTEM Service (terminal_service.rs)
+//!     |
+//!     +-- CreateProcessAsUserW --> Terminal Helper (this module, runs as user)
+//!     |                                |
+//!     |                                +-- CreateProcessW + ConPTY --> Shell
+//!     |                                |
+//!     +-- Named Pipes <----------------+
+//! ```
+
+use hbb_common::{
+    anyhow::{anyhow, Context, Result},
+    log,
+};
+use portable_pty::{CommandBuilder, MasterPty, PtySize};
+use std::{
+    ffi::OsStr,
+    fs::File,
+    io::{Read, Write},
+    os::windows::{ffi::OsStrExt, io::FromRawHandle},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::Duration,
+};
+use windows::{
+    core::PCWSTR,
+    Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    },
+};
+
+/// Message type constants for helper protocol.
+/// Used to distinguish between terminal data and control commands.
+pub const MSG_TYPE_DATA: u8 = 0x00;
+pub const MSG_TYPE_RESIZE: u8 = 0x01;
+
+/// Message header size: 1 byte type + 4 bytes length
+pub const MSG_HEADER_SIZE: usize = 5;
+
+/// Maximum payload size to prevent denial of service from malicious messages.
+/// 16MB should be more than enough for any legitimate terminal data.
+const MAX_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
+
+/// Get the default shell for Windows.
+/// Shared implementation used by both terminal_service and terminal_helper.
+pub fn get_default_shell() -> String {
+    // Try PowerShell Core first
+    let pwsh_paths = [
+        "pwsh.exe",
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\6\pwsh.exe",
+    ];
+
+    for path in &pwsh_paths {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+
+    // Try Windows PowerShell
+    let powershell_path = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe";
+    if std::path::Path::new(powershell_path).exists() {
+        return powershell_path.to_string();
+    }
+
+    // Fallback to cmd.exe
+    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+}
+
+/// Run terminal helper process
+/// Args: --terminal-helper <input_pipe_name> <output_pipe_name> <rows> <cols> [terminal_id]
+pub fn run_terminal_helper(args: &[String]) -> Result<()> {
+    if args.len() < 4 {
+        return Err(anyhow!(
+            "Usage: --terminal-helper <input_pipe> <output_pipe> <rows> <cols> [terminal_id]"
+        ));
+    }
+
+    let input_pipe_name = &args[0];
+    let output_pipe_name = &args[1];
+    let rows: u16 = args[2].parse().unwrap_or(24);
+    let cols: u16 = args[3].parse().unwrap_or(80);
+    let terminal_id: i32 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+    log::debug!(
+        "Terminal helper starting: terminal_id={}, size={}x{}",
+        terminal_id,
+        cols,
+        rows
+    );
+
+    // Open named pipes (created by the service)
+    let input_pipe = open_pipe(input_pipe_name, true)?;
+    let output_pipe = open_pipe(output_pipe_name, false)?;
+
+    // Create ConPTY and shell
+    let pty_size = PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    let pty_system = portable_pty::native_pty_system();
+    let pty_pair = pty_system.openpty(pty_size).context("Failed to open PTY")?;
+
+    let shell = get_default_shell();
+    log::debug!("Using shell: {}", shell);
+
+    let cmd = CommandBuilder::new(&shell);
+    let mut child = pty_pair
+        .slave
+        .spawn_command(cmd)
+        .context("Failed to spawn shell")?;
+
+    let pid = child.process_id().unwrap_or(0);
+    log::debug!("Shell started with PID: {}", pid);
+
+    let mut pty_writer = pty_pair
+        .master
+        .take_writer()
+        .context("Failed to get PTY writer")?;
+
+    let mut pty_reader = pty_pair
+        .master
+        .try_clone_reader()
+        .context("Failed to get PTY reader")?;
+
+    // Wrap pty_pair.master in Arc<Mutex> for sharing with input thread (for resize)
+    let pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(pty_pair.master));
+
+    let exiting = Arc::new(AtomicBool::new(false));
+
+    // Thread: Read from input pipe, parse messages, write data to PTY or handle control commands
+    let exiting_clone = exiting.clone();
+    let pty_master_clone = pty_master.clone();
+    let input_thread = thread::spawn(move || {
+        let mut input_pipe = input_pipe;
+        let mut header_buf = [0u8; MSG_HEADER_SIZE];
+        let mut payload_buf = vec![0u8; 4096];
+
+        loop {
+            if exiting_clone.load(Ordering::SeqCst) {
+                break;
+            }
+
+            // Read message header
+            match read_exact_or_eof(&mut input_pipe, &mut header_buf) {
+                Ok(false) => {
+                    log::debug!("Input pipe EOF");
+                    break;
+                }
+                Ok(true) => {}
+                Err(e) => {
+                    log::error!("Input pipe header read error: {}", e);
+                    break;
+                }
+            }
+
+            let msg_type = header_buf[0];
+            let payload_len =
+                u32::from_le_bytes([header_buf[1], header_buf[2], header_buf[3], header_buf[4]])
+                    as usize;
+
+            // Validate payload length to prevent denial of service
+            if payload_len > MAX_PAYLOAD_SIZE {
+                log::error!(
+                    "Payload too large: {} bytes (max {})",
+                    payload_len,
+                    MAX_PAYLOAD_SIZE
+                );
+                break;
+            }
+
+            // Ensure payload buffer is large enough
+            if payload_buf.len() < payload_len {
+                payload_buf.resize(payload_len, 0);
+            }
+
+            // Read payload
+            if payload_len > 0 {
+                match read_exact_or_eof(&mut input_pipe, &mut payload_buf[..payload_len]) {
+                    Ok(false) => {
+                        log::debug!("Input pipe EOF during payload read");
+                        break;
+                    }
+                    Ok(true) => {}
+                    Err(e) => {
+                        log::error!("Input pipe payload read error: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            match msg_type {
+                MSG_TYPE_DATA => {
+                    // Write terminal data to PTY
+                    if let Err(e) = pty_writer.write_all(&payload_buf[..payload_len]) {
+                        log::error!("PTY write error: {}", e);
+                        break;
+                    }
+                    if let Err(e) = pty_writer.flush() {
+                        log::error!("PTY flush error: {}", e);
+                        break;
+                    }
+                }
+                MSG_TYPE_RESIZE => {
+                    // Parse resize command: rows (u16 LE) + cols (u16 LE)
+                    if payload_len >= 4 {
+                        let rows = u16::from_le_bytes([payload_buf[0], payload_buf[1]]);
+                        let cols = u16::from_le_bytes([payload_buf[2], payload_buf[3]]);
+                        log::debug!("Resize command received: {}x{}", cols, rows);
+
+                        if let Ok(master) = pty_master_clone.lock() {
+                            if let Err(e) = master.resize(PtySize {
+                                rows,
+                                cols,
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            }) {
+                                log::error!("PTY resize error: {}", e);
+                            }
+                        }
+                    } else {
+                        log::warn!("Invalid resize payload length: {}", payload_len);
+                    }
+                }
+                _ => {
+                    log::warn!("Unknown message type: {}", msg_type);
+                }
+            }
+        }
+        log::debug!("Input thread exiting");
+    });
+
+    // Thread: Read from PTY, write to output pipe
+    let exiting_clone = exiting.clone();
+    let output_thread = thread::spawn(move || {
+        let mut output_pipe = output_pipe;
+        let mut buf = vec![0u8; 4096];
+        loop {
+            if exiting_clone.load(Ordering::SeqCst) {
+                break;
+            }
+            match pty_reader.read(&mut buf) {
+                Ok(0) => {
+                    log::debug!("PTY EOF");
+                    break;
+                }
+                Ok(n) => {
+                    if let Err(e) = output_pipe.write_all(&buf[..n]) {
+                        log::error!("Output pipe write error: {}", e);
+                        break;
+                    }
+                    if let Err(e) = output_pipe.flush() {
+                        log::error!("Output pipe flush error: {}", e);
+                        break;
+                    }
+                }
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                        log::error!("PTY read error: {}", e);
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+            }
+        }
+        log::debug!("Output thread exiting");
+    });
+
+    // Wait for child process to exit
+    let exit_status = child.wait();
+    log::info!("Shell exited: {:?}", exit_status);
+
+    exiting.store(true, Ordering::SeqCst);
+
+    // Wait for threads
+    let _ = input_thread.join();
+    let _ = output_thread.join();
+
+    log::info!("Terminal helper exiting");
+    Ok(())
+}
+
+/// Read exactly `buf.len()` bytes from reader.
+/// Returns Ok(true) if successful, Ok(false) on EOF, Err on error.
+fn read_exact_or_eof<R: Read>(reader: &mut R, buf: &mut [u8]) -> std::io::Result<bool> {
+    let mut pos = 0;
+    while pos < buf.len() {
+        match reader.read(&mut buf[pos..]) {
+            Ok(0) => return Ok(false), // EOF
+            Ok(n) => pos += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(true)
+}
+
+/// Open a named pipe as a client.
+/// `for_read`: true for reading (input pipe), false for writing (output pipe).
+fn open_pipe(pipe_name: &str, for_read: bool) -> Result<File> {
+    let wide_name: Vec<u16> = OsStr::new(pipe_name)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let access = if for_read {
+        FILE_GENERIC_READ.0
+    } else {
+        FILE_GENERIC_WRITE.0
+    };
+
+    let handle = unsafe {
+        CreateFileW(
+            PCWSTR::from_raw(wide_name.as_ptr()),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            None,
+        )
+    };
+
+    match handle {
+        Ok(h) => Ok(unsafe { File::from_raw_handle(h.0 as _) }),
+        Err(e) => Err(anyhow!(
+            "Failed to open {} pipe '{}': {}",
+            if for_read { "input" } else { "output" },
+            pipe_name,
+            e
+        )),
+    }
+}

--- a/src/server/terminal_service.rs
+++ b/src/server/terminal_service.rs
@@ -827,17 +827,6 @@ impl TerminalServiceProxy {
         let terminal_id = open.terminal_id;
         let writer_thread = thread::spawn(move || {
             let mut writer = writer;
-            // Write initial carriage return:
-            // 1. Windows requires at least one carriage return for `drop()` to work properly.
-            //    Without this, the reader may fail to read the buffer after `input_tx.send(b"\r\n".to_vec()).ok();`.
-            // 2. This also refreshes the terminal interface on the controlling side (workaround for blank content on connect).
-            if let Err(e) = writer.write_all(b"\r") {
-                log::error!("Terminal {} initial write error: {}", terminal_id, e);
-            } else {
-                if let Err(e) = writer.flush() {
-                    log::error!("Terminal {} initial flush error: {}", terminal_id, e);
-                }
-            }
             while let Ok(data) = input_rx.recv() {
                 if let Err(e) = writer.write_all(&data) {
                     log::error!("Terminal {} write error: {}", terminal_id, e);


### PR DESCRIPTION
May fix https://github.com/rustdesk/rustdesk/issues/13621

## Desc

1. linux as the controlled side
Better way to set env `TERM` for terminal sessions (`--server` sub-process).

  - Retrieve the `TERM` environment variable by checking processes for `["bash", "zsh", "fish", "sh"]`. Iterate through the `/proc/<pid>/environ` files to read the environment variables directly.
  - If `xterm-256color` is found—which is a common case—cache the `TERM` value.
  - If `xterm-256color` is not found in the cache, fall back to iterating through `/proc/<pid>/environ` each time. This overhead is acceptable for non-cached cases.

https://github.com/rustdesk/rustdesk/pull/13895 can be closed when this PR is merged.

2. macOS, fix `htop` command not found.
3. Remove additional "Enter".

## Tests

✅ Verified Items

1. Linux Environments: Works correctly under X11, Wayland, Flatpak, and AppImage. The `TERM` environment variable is set correctly.

2. macOS Environment: `htop` functions as expected.

✅ No Hang-Up on Disconnect Test (20 connection attempts each test)

The following cross-platform connection combinations were tested successfully, with no process hang-up after disconnection:

  - Windows → Linux (X11/Wayland - Deb)
  - Windows → macOS
  - Windows → Windows
  - Linux (X11/Wayland - Deb) → Windows
  - Linux (X11/Wayland - Deb) → macOS
  - macOS → Windows
  - macOS → Linux (X11/Wayland - Deb)
  - Android → Windows
  - Android → Linux (X11/Wayland - Deb)
  - Android → macOS

3. Fix `→ Windows`, `vim.exe` and `claude code cli` hang up.

## Issues

### Terminal Refresh Issue (No Longer Reproducible)

A code block intended to "refresh the terminal interface on the controlling side (workaround for blank content on connect)" has been removed.

Although this issue was previously easy to reproduce, it can no longer be reproduced in current testing, and the terminal displays content correctly upon connection.

```rust

            // Write initial carriage return:
            // 1. Windows requires at least one carriage return for `drop()` to work properly.
            //    Without this, the reader may fail to read the buffer after `input_tx.send(b"\r\n".to_vec()).ok();`.
            // 2. This also refreshes the terminal interface on the controlling side (workaround for blank content on connect).
            if let Err(e) = writer.write_all(b"\r") {
                log::error!("Terminal {} initial write error: {}", terminal_id, e);
            } else {
                if let Err(e) = writer.flush() {
                    log::error!("Terminal {} initial flush error: {}", terminal_id, e);
                }
            }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows: Added a user-context terminal helper to host ConPTY-based shells and relay terminal I/O between system service and user session.
  * Linux: Centralized and improved TERM detection with caching and better heuristics for 256-color support.

* **Chores**
  * Expanded Windows feature flags in the manifest to include additional Win32 capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->