### PR TITLE
Test/strategy

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -234,7 +234,7 @@ jobs:
           path: rustdesk
 
       - name: Sign rustdesk files
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
+        if: false
         shell: bash
         run: |
           pip3 install requests argparse
@@ -266,7 +266,7 @@ jobs:
           sha256sum ../../SignOutput/rustdesk-*.msi
 
       - name: Sign rustdesk self-extracted file
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
+        if: false
         shell: bash
         run: |
           BASE_URL=${{ env.SIGN_BASE_URL }} SECRET_KEY=${{ secrets.SIGN_SECRET_KEY }} python3 res/job.py sign_files ./SignOutput
@@ -400,7 +400,7 @@ jobs:
           path: Release
 
       - name: Sign rustdesk files
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
+        if: false
         shell: bash
         run: |
           pip3 install requests argparse
@@ -418,7 +418,7 @@ jobs:
           mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}-sciter.exe
 
       - name: Sign rustdesk self-extracted file
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
+        if: false
         shell: bash
         run: |
           BASE_URL=${{ env.SIGN_BASE_URL }} SECRET_KEY=${{ secrets.SIGN_SECRET_KEY }} python3 res/job.py sign_files ./SignOutput/

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -12,4 +12,4 @@ jobs:
     secrets: inherit
     with:
       upload-artifact: true
-      upload-tag: "nightly"
+      upload-tag: "test-controlling-strategy"

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3016,10 +3016,19 @@ Future<void> start_service(bool is_start) async {
 }
 
 Future<bool> canBeBlocked() async {
-  var access_mode = await bind.mainGetOption(key: kOptionAccessMode);
+  // First check local settings
+  var accessMode = await bind.mainGetOption(key: kOptionAccessMode);
+  var customAccessMode = accessMode != 'full' && accessMode != 'view';
   var option = option2bool(kOptionAllowRemoteConfigModification,
       await bind.mainGetOption(key: kOptionAllowRemoteConfigModification));
-  return access_mode == 'view' || (access_mode.isEmpty && !option);
+  if (accessMode == 'view' || (customAccessMode && !option)) {
+    return true;
+  }
+  // Local settings allow, check controlling strategy
+  final disabledByStrategy = await bind.mainGetCommon(
+          key: "is-remote-modify-disabled-by-controlling-strategy") ==
+      "true";
+  return disabledByStrategy;
 }
 
 // to-do: web not implemented

--- a/src/common.rs
+++ b/src/common.rs
@@ -2265,6 +2265,19 @@ pub fn str2color(s: &str, alpha: u8) -> u32 {
     (alpha as u32) << 24 | rgb
 }
 
+pub fn is_feature_disabled_by_controlling_strategy(
+    disabled_features: u64,
+    feature: hbb_common::rendezvous_proto::controlling_strategy::Feature,
+) -> bool {
+    use hbb_common::protobuf::Enum;
+    let bit = feature.value();
+    if bit >= 0 && bit < 64 {
+        (disabled_features & (1 << bit)) != 0
+    } else {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2600,6 +2600,8 @@ pub fn main_get_common(key: String) -> String {
         return false.to_string();
     } else if key == "transfer-job-id" {
         return hbb_common::fs::get_next_job_id().to_string();
+    } else if key == "is-remote-modify-disabled-by-controlling-strategy" {
+        return is_remote_modify_disabled_by_controlling_strategy().to_string();
     } else {
         if key.starts_with("download-data-") {
             let id = key.replace("download-data-", "");

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -427,6 +427,7 @@ impl RendezvousMediator {
             rr.secure,
             false,
             Default::default(),
+            rr.controlling_strategy.clone().into_option(),
         )
         .await
     }
@@ -440,6 +441,7 @@ impl RendezvousMediator {
         secure: bool,
         initiate: bool,
         socket_addr_v6: bytes::Bytes,
+        controlling_strategy: Option<ControllingStrategy>,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&socket_addr);
         log::info!(
@@ -473,6 +475,7 @@ impl RendezvousMediator {
             peer_addr,
             secure,
             is_ipv4(&self.addr),
+            controlling_strategy,
         )
         .await;
         Ok(())
@@ -491,7 +494,13 @@ impl RendezvousMediator {
         let relay = use_ws() || Config::is_proxy();
         let mut socket_addr_v6 = Default::default();
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(peer_addr_v6, addr, server.clone()).await;
+            socket_addr_v6 = start_ipv6(
+                peer_addr_v6,
+                addr,
+                server.clone(),
+                fla.controlling_strategy.clone().into_option(),
+            )
+            .await;
         }
         if is_ipv4(&self.addr) && !relay && !config::is_disable_tcp_listen() {
             if let Err(err) = self
@@ -517,6 +526,7 @@ impl RendezvousMediator {
             true,
             true,
             socket_addr_v6,
+            fla.controlling_strategy.into_option(),
         )
         .await
     }
@@ -547,7 +557,14 @@ impl RendezvousMediator {
         });
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true).await;
+        crate::accept_connection(
+            server.clone(),
+            socket,
+            peer_addr,
+            true,
+            fla.controlling_strategy.into_option(),
+        )
+        .await;
         Ok(())
     }
 
@@ -562,8 +579,16 @@ impl RendezvousMediator {
         let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
+        // Extract permission controlling_strategy from PunchHole message
+        let controlling_strategy = ph.controlling_strategy.into_option();
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(peer_addr_v6, peer_addr, server.clone()).await;
+            socket_addr_v6 = start_ipv6(
+                peer_addr_v6,
+                peer_addr,
+                server.clone(),
+                controlling_strategy.clone(),
+            )
+            .await;
         }
         let relay_server = self.get_relay_server(ph.relay_server);
         // for ensure, websocket go relay directly
@@ -582,6 +607,7 @@ impl RendezvousMediator {
                     true,
                     true,
                     socket_addr_v6.clone(),
+                    controlling_strategy,
                 )
                 .await;
         }
@@ -598,7 +624,8 @@ impl RendezvousMediator {
         };
         if ph.udp_port > 0 {
             peer_addr.set_port(ph.udp_port as u16);
-            self.punch_udp_hole(peer_addr, server, msg_punch).await?;
+            self.punch_udp_hole(peer_addr, server, msg_punch, controlling_strategy)
+                .await?;
             return Ok(());
         }
         log::debug!("Punch tcp hole to {:?}", peer_addr);
@@ -614,7 +641,14 @@ impl RendezvousMediator {
         msg_out.set_punch_hole_sent(msg_punch);
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true).await;
+        crate::accept_connection(
+            server.clone(),
+            socket,
+            peer_addr,
+            true,
+            controlling_strategy,
+        )
+        .await;
         Ok(())
     }
 
@@ -623,6 +657,7 @@ impl RendezvousMediator {
         peer_addr: SocketAddr,
         server: ServerPtr,
         msg_punch: PunchHoleSent,
+        controlling_strategy: Option<ControllingStrategy>,
     ) -> ResultType<()> {
         let mut msg_out = Message::new();
         msg_out.set_punch_hole_sent(msg_punch);
@@ -637,7 +672,14 @@ impl RendezvousMediator {
                 socket.send_to(&data, addr).await.ok();
             }
         });
-        udp_nat_listen(socket_cloned.clone(), peer_addr, peer_addr, server).await?;
+        udp_nat_listen(
+            socket_cloned.clone(),
+            peer_addr,
+            peer_addr,
+            server,
+            controlling_strategy,
+        )
+        .await?;
         Ok(())
     }
 
@@ -778,6 +820,7 @@ async fn direct_server(server: ServerPtr) {
                             hbb_common::Stream::from(stream, local_addr),
                             addr,
                             false,
+                            None, // Direct connections don't have controlling_strategy
                         )
                         .await
                     );
@@ -809,12 +852,22 @@ async fn start_ipv6(
     peer_addr_v6: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
+    controlling_strategy: Option<ControllingStrategy>,
 ) -> bytes::Bytes {
     crate::test_ipv6().await;
     if let Some((socket, local_addr_v6)) = crate::get_ipv6_socket().await {
         let server = server.clone();
         tokio::spawn(async move {
-            allow_err!(udp_nat_listen(socket.clone(), peer_addr_v6, peer_addr_v4, server).await);
+            allow_err!(
+                udp_nat_listen(
+                    socket.clone(),
+                    peer_addr_v6,
+                    peer_addr_v4,
+                    server,
+                    controlling_strategy
+                )
+                .await
+            );
         });
         return local_addr_v6;
     }
@@ -826,6 +879,7 @@ async fn udp_nat_listen(
     peer_addr: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
+    controlling_strategy: Option<ControllingStrategy>,
 ) -> ResultType<()> {
     let tm = Instant::now();
     let socket_cloned = socket.clone();
@@ -838,7 +892,14 @@ async fn udp_nat_listen(
             res,
         )
         .await?;
-        crate::server::create_tcp_connection(server, stream.1, peer_addr_v4, true).await?;
+        crate::server::create_tcp_connection(
+            server,
+            stream.1,
+            peer_addr_v4,
+            true,
+            controlling_strategy,
+        )
+        .await?;
         Ok(())
     };
     func.await.map_err(|e: anyhow::Error| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -152,18 +152,30 @@ pub fn new() -> ServerPtr {
     Arc::new(RwLock::new(server))
 }
 
-async fn accept_connection_(server: ServerPtr, socket: Stream, secure: bool) -> ResultType<()> {
+async fn accept_connection_(
+    server: ServerPtr,
+    socket: Stream,
+    secure: bool,
+    controlling_strategy: Option<ControllingStrategy>,
+) -> ResultType<()> {
     let local_addr = socket.local_addr();
     drop(socket);
     // even we drop socket, below still may fail if not use reuse_addr,
     // there is TIME_WAIT before socket really released, so sometimes we
-    // see “Only one usage of each socket address is normally permitted” on windows sometimes,
+    // see "Only one usage of each socket address is normally permitted" on windows sometimes,
     let listener = new_listener(local_addr, true).await?;
     log::info!("Server listening on: {}", &listener.local_addr()?);
     if let Ok((stream, addr)) = timeout(CONNECT_TIMEOUT, listener.accept()).await? {
         stream.set_nodelay(true).ok();
         let stream_addr = stream.local_addr()?;
-        create_tcp_connection(server, Stream::from(stream, stream_addr), addr, secure).await?;
+        create_tcp_connection(
+            server,
+            Stream::from(stream, stream_addr),
+            addr,
+            secure,
+            controlling_strategy,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -173,6 +185,7 @@ pub async fn create_tcp_connection(
     stream: Stream,
     addr: SocketAddr,
     secure: bool,
+    controlling_strategy: Option<ControllingStrategy>,
 ) -> ResultType<()> {
     let mut stream = stream;
     let id = server.write().unwrap().get_new_id();
@@ -240,7 +253,14 @@ pub async fn create_tcp_connection(
         }
         log::info!("wake up macos");
     }
-    Connection::start(addr, stream, id, Arc::downgrade(&server)).await;
+    Connection::start(
+        addr,
+        stream,
+        id,
+        Arc::downgrade(&server),
+        controlling_strategy,
+    )
+    .await;
     Ok(())
 }
 
@@ -249,8 +269,9 @@ pub async fn accept_connection(
     socket: Stream,
     peer_addr: SocketAddr,
     secure: bool,
+    controlling_strategy: Option<ControllingStrategy>,
 ) {
-    if let Err(err) = accept_connection_(server, socket, secure).await {
+    if let Err(err) = accept_connection_(server, socket, secure, controlling_strategy).await {
         log::warn!("Failed to accept connection from {}: {}", peer_addr, err);
     }
 }
@@ -262,9 +283,18 @@ pub async fn create_relay_connection(
     peer_addr: SocketAddr,
     secure: bool,
     ipv4: bool,
+    controlling_strategy: Option<ControllingStrategy>,
 ) {
-    if let Err(err) =
-        create_relay_connection_(server, relay_server, uuid.clone(), peer_addr, secure, ipv4).await
+    if let Err(err) = create_relay_connection_(
+        server,
+        relay_server,
+        uuid.clone(),
+        peer_addr,
+        secure,
+        ipv4,
+        controlling_strategy,
+    )
+    .await
     {
         log::error!(
             "Failed to create relay connection for {} with uuid {}: {}",
@@ -282,6 +312,7 @@ async fn create_relay_connection_(
     peer_addr: SocketAddr,
     secure: bool,
     ipv4: bool,
+    controlling_strategy: Option<ControllingStrategy>,
 ) -> ResultType<()> {
     let mut stream = socket_client::connect_tcp(
         socket_client::ipv4_to_ipv6(crate::check_port(relay_server, RELAY_PORT), ipv4),
@@ -296,7 +327,7 @@ async fn create_relay_connection_(
         ..Default::default()
     });
     stream.send(&msg_out).await?;
-    create_tcp_connection(server, stream, peer_addr, secure).await?;
+    create_tcp_connection(server, stream, peer_addr, secure, controlling_strategy).await?;
     Ok(())
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -33,6 +33,7 @@ use hbb_common::{
     get_time, get_version_number,
     message_proto::{option_message::BoolOption, permission_info::Permission},
     password_security::{self as password, ApproveMode},
+    rendezvous_proto::controlling_strategy::Feature,
     sha2::{Digest, Sha256},
     sleep, timeout,
     tokio::{
@@ -72,6 +73,7 @@ lazy_static::lazy_static! {
     static ref SESSIONS: Arc::<Mutex<HashMap<SessionKey, Session>>> = Default::default();
     static ref ALIVE_CONNS: Arc::<Mutex<Vec<i32>>> = Default::default();
     pub static ref AUTHED_CONNS: Arc::<Mutex<Vec<AuthedConn>>> = Default::default();
+    pub static ref CONTROLLING_STRATEGIES: Arc::<Mutex<Vec<(i32, ControllingStrategy)>>> = Default::default();
     static ref SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
     static ref WAKELOCK_SENDER: Arc::<Mutex<std::sync::mpsc::Sender<(usize, usize)>>> = Arc::new(Mutex::new(start_wakelock_thread()));
 }
@@ -227,6 +229,7 @@ pub struct Connection {
     restart: bool,
     recording: bool,
     block_input: bool,
+    controlling_strategy: Option<ControllingStrategy>,
     last_test_delay: Option<Instant>,
     network_delay: u32,
     lock_after_session_end: bool,
@@ -345,8 +348,10 @@ impl Connection {
         stream: super::Stream,
         id: i32,
         server: super::ServerPtrWeak,
+        controlling_strategy: Option<ControllingStrategy>,
     ) {
         let _raii_id = raii::ConnectionID::new(id);
+        let _raii_policy_id = raii::ControllingStrategyID::new(id, &controlling_strategy);
         let hash = Hash {
             salt: Config::get_salt(),
             challenge: Config::get_auto_password(6),
@@ -397,14 +402,15 @@ impl Connection {
             port_forward_address: "".to_owned(),
             tx_to_cm,
             authorized: false,
-            keyboard: Connection::permission("enable-keyboard"),
-            clipboard: Connection::permission("enable-clipboard"),
-            audio: Connection::permission("enable-audio"),
+            keyboard: Self::permission(keys::OPTION_ENABLE_KEYBOARD, &controlling_strategy),
+            clipboard: Self::permission(keys::OPTION_ENABLE_CLIPBOARD, &controlling_strategy),
+            audio: Self::permission(keys::OPTION_ENABLE_AUDIO, &controlling_strategy),
             // to-do: make sure is the option correct here
-            file: Connection::permission(keys::OPTION_ENABLE_FILE_TRANSFER),
-            restart: Connection::permission("enable-remote-restart"),
-            recording: Connection::permission("enable-record-session"),
-            block_input: Connection::permission("enable-block-input"),
+            file: Self::permission(keys::OPTION_ENABLE_FILE_TRANSFER, &controlling_strategy),
+            restart: Self::permission(keys::OPTION_ENABLE_REMOTE_RESTART, &controlling_strategy),
+            recording: Self::permission(keys::OPTION_ENABLE_RECORD_SESSION, &controlling_strategy),
+            block_input: Self::permission(keys::OPTION_ENABLE_BLOCK_INPUT, &controlling_strategy),
+            controlling_strategy,
             last_test_delay: None,
             network_delay: 0,
             lock_after_session_end: false,
@@ -850,7 +856,7 @@ impl Connection {
                     match data {
                         #[cfg(all(target_os = "windows", feature = "flutter"))]
                         ipc::Data::PrinterData(data) => {
-                            if config::Config::get_bool_option(config::keys::OPTION_ENABLE_REMOTE_PRINTER) {
+                            if Self::permission(keys::OPTION_ENABLE_REMOTE_PRINTER, &conn.controlling_strategy) {
                                 conn.send_printer_request(data).await;
                             } else {
                                 conn.send_remote_printing_disallowed().await;
@@ -1907,7 +1913,8 @@ impl Connection {
         false
     }
 
-    pub fn permission(enable_prefix_option: &str) -> bool {
+    #[inline]
+    fn is_local_permission_enabled(enable_prefix_option: &str) -> bool {
         #[cfg(feature = "flutter")]
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
@@ -1922,6 +1929,39 @@ impl Connection {
             enable_prefix_option,
             &Config::get_option(enable_prefix_option),
         )
+    }
+
+    fn permission(enable_prefix_option: &str, policy: &Option<ControllingStrategy>) -> bool {
+        if !Self::is_local_permission_enabled(enable_prefix_option) {
+            return false;
+        }
+        let mut option = true;
+        if let Some(policy) = policy {
+            let feature = match enable_prefix_option {
+                keys::OPTION_ENABLE_KEYBOARD => Some(Feature::keyboard),
+                keys::OPTION_ENABLE_REMOTE_PRINTER => Some(Feature::remote_printer),
+                keys::OPTION_ENABLE_CLIPBOARD => Some(Feature::clipboard),
+                keys::OPTION_ENABLE_FILE_TRANSFER => Some(Feature::file),
+                keys::OPTION_ENABLE_AUDIO => Some(Feature::audio),
+                keys::OPTION_ENABLE_CAMERA => Some(Feature::camera),
+                keys::OPTION_ENABLE_TERMINAL => Some(Feature::terminal),
+                keys::OPTION_ENABLE_TUNNEL => Some(Feature::tunnel),
+                keys::OPTION_ENABLE_REMOTE_RESTART => Some(Feature::restart),
+                keys::OPTION_ENABLE_RECORD_SESSION => Some(Feature::recording),
+                keys::OPTION_ENABLE_BLOCK_INPUT => Some(Feature::block_input),
+                _ => None,
+            };
+            if let Some(feature) = feature {
+                if crate::is_feature_disabled_by_controlling_strategy(
+                    policy.disabled_features,
+                    feature,
+                ) {
+                    option = false;
+                }
+            }
+        }
+
+        option
     }
 
     fn update_codec_on_login(&self) {
@@ -2019,7 +2059,10 @@ impl Connection {
             }
             match lr.union {
                 Some(login_request::Union::FileTransfer(ft)) => {
-                    if !Connection::permission(keys::OPTION_ENABLE_FILE_TRANSFER) {
+                    if !Self::permission(
+                        keys::OPTION_ENABLE_FILE_TRANSFER,
+                        &self.controlling_strategy,
+                    ) {
                         self.send_login_error("No permission of file transfer")
                             .await;
                         sleep(1.).await;
@@ -2028,7 +2071,7 @@ impl Connection {
                     self.file_transfer = Some((ft.dir, ft.show_hidden));
                 }
                 Some(login_request::Union::ViewCamera(_vc)) => {
-                    if !Connection::permission(keys::OPTION_ENABLE_CAMERA) {
+                    if !Self::permission(keys::OPTION_ENABLE_CAMERA, &self.controlling_strategy) {
                         self.send_login_error("No permission of viewing camera")
                             .await;
                         sleep(1.).await;
@@ -2037,7 +2080,7 @@ impl Connection {
                     self.view_camera = true;
                 }
                 Some(login_request::Union::Terminal(terminal)) => {
-                    if !Connection::permission(keys::OPTION_ENABLE_TERMINAL) {
+                    if !Self::permission(keys::OPTION_ENABLE_TERMINAL, &self.controlling_strategy) {
                         self.send_login_error("No permission of terminal").await;
                         sleep(1.).await;
                         return false;
@@ -2085,7 +2128,7 @@ impl Connection {
                     }
                 }
                 Some(login_request::Union::PortForward(mut pf)) => {
-                    if !Connection::permission("enable-tunnel") {
+                    if !Self::permission(keys::OPTION_ENABLE_TUNNEL, &self.controlling_strategy) {
                         self.send_login_error("No permission of IP tunneling").await;
                         sleep(1.).await;
                         return false;
@@ -4822,6 +4865,7 @@ pub struct AuthedConn {
 mod raii {
     // ALIVE_CONNS: all connections, including unauthorized connections
     // AUTHED_CONNS: all authorized connections
+    // CONTROLLING_STRATEGY: all non-None controlling strategies
 
     use super::*;
     pub struct ConnectionID(i32);
@@ -5009,6 +5053,31 @@ mod raii {
             {
                 use crate::whiteboard;
                 whiteboard::unregister_whiteboard(whiteboard::get_key_cursor(self.0));
+            }
+        }
+    }
+
+    pub struct ControllingStrategyID {
+        id: i32,
+        strategy: Option<ControllingStrategy>,
+    }
+
+    impl Drop for ControllingStrategyID {
+        fn drop(&mut self) {
+            if self.strategy.is_some() {
+                let mut lock = CONTROLLING_STRATEGIES.lock().unwrap();
+                lock.retain(|(conn_id, _)| *conn_id != self.id);
+            }
+        }
+    }
+    impl ControllingStrategyID {
+        pub fn new(id: i32, strategy: &Option<ControllingStrategy>) -> Self {
+            if let Some(s) = strategy {
+                CONTROLLING_STRATEGIES.lock().unwrap().push((id, s.clone()));
+            }
+            Self {
+                id,
+                strategy: strategy.clone(),
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -699,6 +699,10 @@ impl UI {
     fn get_builtin_option(&self, key: String) -> String {
         crate::ui_interface::get_builtin_option(&key)
     }
+
+    fn is_remote_modify_disabled_by_controlling_strategy(&self) -> bool {
+        crate::ui_interface::is_remote_modify_disabled_by_controlling_strategy()
+    }
 }
 
 impl sciter::EventHandler for UI {
@@ -801,6 +805,7 @@ impl sciter::EventHandler for UI {
         fn verify_login(String, String);
         fn is_option_fixed(String);
         fn get_builtin_option(String);
+        fn is_remote_modify_disabled_by_controlling_strategy();
     }
 }
 

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1394,7 +1394,7 @@ function self.onMouse(evt) {
 }
 
 function check_if_overlay() {
-    if (handler.get_option('allow-remote-config-modification') != 'Y') {
+    if (handler.get_option('allow-remote-config-modification') != 'Y' || handler.is_remote_modify_disabled_by_controlling_strategy()) {
         var time0 = getTime();
         handler.check_mouse_time();
         self.timer(120ms, function() {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk-server-pro/discussions/718
https://github.com/rustdesk/hbb_common/pull/471

## Summary
  Add controlling strategy to restrict remote control permissions for different users (including unauthenticated users). These permissions correspond to the options in Settings -> Security -> Permissions on the client side

## Implementation details:
  1. Permission info is received via server's `PunchHole`, `FetchLocalAddr`, and `RequestRelay` responses, then passed directly to `Connection::start`. Direct IP access is not restricted.
  2. Only disabling permissions is supported - server-side restrictions cannot grant more permissions than the local client settings allow.
  3. For the "Remote configuration modification" option, if any user has this disabled, it will be disabled for all connections.


## Video

https://github.com/user-attachments/assets/0a3b9d1d-eabd-4d43-a4c4-c4a6ba82b5ad



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented controlling strategy framework for enforcing policy-based access control on remote connections. This enables selective feature restrictions on a per-connection basis to meet organizational security standards and compliance requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->