### PR TITLE
fix(terminal): improve persistent session handling and new tab UX

### DIFF
--- a/flutter/lib/desktop/pages/terminal_page.dart
+++ b/flutter/lib/desktop/pages/terminal_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common.dart';
@@ -15,6 +16,7 @@ class TerminalPage extends StatefulWidget {
     required this.tabController,
     required this.isSharedPassword,
     required this.terminalId,
+    required this.tabKey,
     this.forceRelay,
     this.connToken,
   }) : super(key: key);
@@ -25,6 +27,8 @@ class TerminalPage extends StatefulWidget {
   final bool? isSharedPassword;
   final String? connToken;
   final int terminalId;
+  /// Tab key for focus management, passed from parent to avoid duplicate construction
+  final String tabKey;
   final SimpleWrapper<State<TerminalPage>?> _lastState = SimpleWrapper(null);
 
   FFI get ffi => (_lastState.value! as _TerminalPageState)._ffi;
@@ -42,10 +46,15 @@ class _TerminalPageState extends State<TerminalPage>
   late FFI _ffi;
   late TerminalModel _terminalModel;
   double? _cellHeight;
+  final FocusNode _terminalFocusNode = FocusNode(canRequestFocus: false);
+  StreamSubscription<DesktopTabState>? _tabStateSubscription;
 
   @override
   void initState() {
     super.initState();
+
+    // Listen for tab selection changes to request focus
+    _tabStateSubscription = widget.tabController.state.listen(_onTabStateChanged);
 
     // Use shared FFI instance from connection manager
     _ffi = TerminalConnectionManager.getConnection(
@@ -63,6 +72,13 @@ class _TerminalPageState extends State<TerminalPage>
 
     _terminalModel.onResizeExternal = (w, h, pw, ph) {
       _cellHeight = ph * 1.0;
+
+      // Enable focus once terminal has valid dimensions (first valid resize)
+      if (!_terminalFocusNode.canRequestFocus && w > 0 && h > 0) {
+        _terminalFocusNode.canRequestFocus = true;
+        // Auto-focus if this tab is currently selected
+        _requestFocusIfSelected();
+      }
 
       // Schedule the setState for the next frame
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -94,17 +110,46 @@ class _TerminalPageState extends State<TerminalPage>
         // Open the terminal directly
         _terminalModel.openTerminal();
       }
+
     });
   }
 
   @override
   void dispose() {
+    // Cancel tab state subscription to prevent memory leak
+    _tabStateSubscription?.cancel();
     // Unregister terminal model from FFI
     _ffi.unregisterTerminalModel(widget.terminalId);
     _terminalModel.dispose();
+    _terminalFocusNode.dispose();
     // Release connection reference instead of closing directly
     TerminalConnectionManager.releaseConnection(widget.id);
     super.dispose();
+  }
+
+  void _onTabStateChanged(DesktopTabState state) {
+    // Check if this tab is now selected and request focus
+    if (state.selected >= 0 && state.selected < state.tabs.length) {
+      final selectedTab = state.tabs[state.selected];
+      if (selectedTab.key == widget.tabKey && mounted) {
+        _requestFocusIfSelected();
+      }
+    }
+  }
+
+  void _requestFocusIfSelected() {
+    if (!mounted || !_terminalFocusNode.canRequestFocus) return;
+    // Use post-frame callback to ensure widget is fully laid out in focus tree
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Re-check conditions after frame: mounted, focusable, still selected, not already focused
+      if (!mounted || !_terminalFocusNode.canRequestFocus || _terminalFocusNode.hasFocus) return;
+      final state = widget.tabController.state.value;
+      if (state.selected >= 0 && state.selected < state.tabs.length) {
+        if (state.tabs[state.selected].key == widget.tabKey) {
+          _terminalFocusNode.requestFocus();
+        }
+      }
+    });
   }
 
   // This method ensures that the number of visible rows is an integer by computing the
@@ -131,7 +176,9 @@ class _TerminalPageState extends State<TerminalPage>
           return TerminalView(
             _terminalModel.terminal,
             controller: _terminalModel.terminalController,
-            autofocus: true,
+            focusNode: _terminalFocusNode,
+            // Note: autofocus is not used here because focus is managed manually
+            // via _onTabStateChanged() to handle tab switching properly.
             backgroundOpacity: 0.7,
             padding: _calculatePadding(heightPx),
             onSecondaryTapDown: (details, offset) async {

--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -34,6 +34,8 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
   static const IconData selectedIcon = Icons.terminal;
   static const IconData unselectedIcon = Icons.terminal_outlined;
   int _nextTerminalId = 1;
+  // Lightweight idempotency guard for async close operations
+  final Set<String> _closingTabs = {};
 
   _TerminalTabPageState(Map<String, dynamic> params) {
     Get.put(DesktopTabController(tabType: DesktopTabType.terminal));
@@ -70,28 +72,12 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
       label: tabLabel,
       selectedIcon: selectedIcon,
       unselectedIcon: unselectedIcon,
-      onTabCloseButton: () async {
-        if (await desktopTryShowTabAuditDialogCloseCancelled(
-          id: tabKey,
-          tabController: tabController,
-        )) {
-          return;
-        }
-        // Close the terminal session first
-        final ffi = TerminalConnectionManager.getExistingConnection(peerId);
-        if (ffi != null) {
-          final terminalModel = ffi.terminalModels[terminalId];
-          if (terminalModel != null) {
-            await terminalModel.closeTerminal();
-          }
-        }
-        // Then close the tab
-        tabController.closeBy(tabKey);
-      },
+      onTabCloseButton: () => _closeTab(tabKey),
       page: TerminalPage(
         key: ValueKey(tabKey),
         id: peerId,
         terminalId: terminalId,
+        tabKey: tabKey,
         password: password,
         isSharedPassword: isSharedPassword,
         tabController: tabController,
@@ -99,6 +85,72 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
         connToken: connToken,
       ),
     );
+  }
+
+  /// Unified tab close handler for all close paths (button, shortcut, programmatic).
+  /// Checks persistent mode and only sends CloseTerminal if not persistent.
+  /// @param showAudit: whether to show audit dialog (false for batch close)
+  Future<void> _closeTab(String tabKey, {bool showAudit = true}) async {
+    // Idempotency guard: skip if already closing this tab
+    if (_closingTabs.contains(tabKey)) return;
+    _closingTabs.add(tabKey);
+
+    try {
+      if (showAudit) {
+        // Show audit dialog if needed; if user cancels, abort close
+        if (await desktopTryShowTabAuditDialogCloseCancelled(
+          id: tabKey,
+          tabController: tabController,
+        )) {
+          return;
+        }
+      }
+
+      // Close terminal session if not in persistent mode
+      await _closeTerminalSessionIfNeeded(tabKey);
+      // Close the tab from UI
+      tabController.closeBy(tabKey);
+    } catch (e) {
+      debugPrint('[TerminalTabPage] Error closing tab $tabKey: $e');
+    } finally {
+      _closingTabs.remove(tabKey);
+    }
+  }
+
+  /// Close all tabs with proper session cleanup.
+  /// Used for window-level close operations (onDestroy, handleWindowCloseButton).
+  /// Reuses _closeTab() for unified close path and idempotency protection.
+  Future<void> _closeAllTabs() async {
+    // Get all tab keys before closing (avoid modifying while iterating)
+    final tabKeys = tabController.state.value.tabs.map((t) => t.key).toList();
+    // Close all tabs sequentially (showAudit: false for batch close)
+    for (final tabKey in tabKeys) {
+      await _closeTab(tabKey, showAudit: false);
+    }
+  }
+
+  /// Close the terminal session on server side if persistent mode is disabled.
+  Future<void> _closeTerminalSessionIfNeeded(String tabKey) async {
+    final parsed = _parseTabKey(tabKey);
+    if (parsed == null) return;
+    final (peerId, terminalId) = parsed;
+
+    final ffi = TerminalConnectionManager.getExistingConnection(peerId);
+    if (ffi == null) return;
+
+    final isPersistent = bind.sessionGetToggleOptionSync(
+      sessionId: ffi.sessionId,
+      arg: kOptionTerminalPersistent,
+    );
+
+    // Only close terminal session if not in persistent mode
+    if (!isPersistent) {
+      final terminalModel = ffi.terminalModels[terminalId];
+      if (terminalModel != null) {
+        // closeTerminal() has internal 3s timeout, no need for external timeout
+        await terminalModel.closeTerminal();
+      }
+    }
   }
 
   Widget _tabMenuBuilder(String peerId, CancelFunc cancelFunc) {
@@ -184,7 +236,8 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
       } else if (call.method == kWindowEventRestoreTerminalSessions) {
         _restoreSessions(call.arguments);
       } else if (call.method == "onDestroy") {
-        tabController.clear();
+        // Use unified close path for proper session cleanup
+        await _closeAllTabs();
       } else if (call.method == kWindowActionRebuild) {
         reloadCurrentWindow();
       } else if (call.method == kWindowEventActiveSession) {
@@ -265,7 +318,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
           // macOS: Cmd+W (standard for close tab)
           final currentTab = tabController.state.value.selectedTabInfo;
           if (tabController.state.value.tabs.length > 1) {
-            tabController.closeBy(currentTab.key);
+            _closeTab(currentTab.key);
             return true;
           }
         } else if (!isMacOS &&
@@ -274,7 +327,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
           // Other platforms: Ctrl+Shift+W (to avoid conflict with Ctrl+W word delete)
           final currentTab = tabController.state.value.selectedTabInfo;
           if (tabController.state.value.tabs.length > 1) {
-            tabController.closeBy(currentTab.key);
+            _closeTab(currentTab.key);
             return true;
           }
         }
@@ -329,7 +382,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
   void _addNewTerminal(String peerId, {int? terminalId}) {
     // Find first tab for this peer to get connection parameters
     final firstTab = tabController.state.value.tabs.firstWhere(
-      (tab) => tab.key.startsWith('$peerId\_'),
+      (tab) => tab.key.startsWith('${peerId}_'),
     );
     if (firstTab.page is TerminalPage) {
       final page = firstTab.page as TerminalPage;
@@ -337,6 +390,8 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
       if (terminalId != null && terminalId >= _nextTerminalId) {
         _nextTerminalId = terminalId + 1;
       }
+      // tabController.add() already handles jumpTo internally (see tabbar_widget.dart:108)
+      // It jumps to existing tab if key exists, or to new tab if added
       tabController.add(_createTerminalTab(
         peerId: peerId,
         terminalId: newTerminalId,
@@ -350,11 +405,29 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
 
   void _addNewTerminalForCurrentPeer({int? terminalId}) {
     final currentTab = tabController.state.value.selectedTabInfo;
-    final parts = currentTab.key.split('_');
-    if (parts.isNotEmpty) {
-      final peerId = parts[0];
-      _addNewTerminal(peerId, terminalId: terminalId);
+    final parsed = _parseTabKey(currentTab.key);
+    if (parsed == null) return;
+    final (peerId, _) = parsed;
+    _addNewTerminal(peerId, terminalId: terminalId);
+  }
+
+  /// Parse tabKey (format: "peerId_terminalId") into its components.
+  /// Note: peerId may contain underscores, so we use lastIndexOf('_').
+  /// Returns null if tabKey format is invalid.
+  (String peerId, int terminalId)? _parseTabKey(String tabKey) {
+    final lastUnderscore = tabKey.lastIndexOf('_');
+    if (lastUnderscore <= 0) {
+      debugPrint('[TerminalTabPage] Invalid tabKey format: $tabKey');
+      return null;
     }
+    final terminalIdStr = tabKey.substring(lastUnderscore + 1);
+    final terminalId = int.tryParse(terminalIdStr);
+    if (terminalId == null) {
+      debugPrint('[TerminalTabPage] Invalid terminalId in tabKey: $tabKey');
+      return null;
+    }
+    final peerId = tabKey.substring(0, lastUnderscore);
+    return (peerId, terminalId);
   }
 
   @override
@@ -368,10 +441,9 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
           selectedBorderColor: MyTheme.accent,
           labelGetter: DesktopTab.tablabelGetter,
           tabMenuBuilder: (key) {
-            // Extract peerId from tab key (format: "peerId_terminalId")
-            final parts = key.split('_');
-            if (parts.isEmpty) return Container();
-            final peerId = parts[0];
+            final parsed = _parseTabKey(key);
+            if (parsed == null) return Container();
+            final (peerId, _) = parsed;
             return _tabMenuBuilder(peerId, () {});
           },
         ));
@@ -426,7 +498,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
       }
     }
     if (connLength <= 1) {
-      tabController.clear();
+      await _closeAllTabs();
       return true;
     } else {
       final bool res;
@@ -437,7 +509,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
         res = await closeConfirmDialog();
       }
       if (res) {
-        tabController.clear();
+        await _closeAllTabs();
       }
       return res;
     }

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -24,6 +24,18 @@ class TerminalModel with ChangeNotifier {
   bool _disposed = false;
 
   final _inputBuffer = <String>[];
+  // Buffer for output data received before terminal view has valid dimensions.
+  // This prevents NaN errors when writing to terminal before layout is complete.
+  // Uses List<String> chunks to avoid truncating ANSI escape sequences mid-stream.
+  final _pendingOutputChunks = <String>[];
+  int _pendingOutputSize = 0;  // in characters (UTF-16 code units)
+  // Local buffer limit (characters) - aligned with server's request buffer size.
+  // Note: UTF-8 bytes on server vs UTF-16 chars here, but close enough for buffering purposes.
+  static const int _kMaxOutputBufferChars = 8 * 1024;
+  // Max bytes to request from server when reconnecting to a persistent session.
+  static const int _kMaxRequestBufferBytes = 8 * 1024;
+  // View ready state: true when terminal has valid dimensions, safe to write
+  bool _terminalViewReady = false;
 
   bool get isPeerWindows => parent.ffiModel.pi.platform == kPeerPlatformWindows;
 
@@ -70,6 +82,11 @@ class TerminalModel with ChangeNotifier {
       if (w > 0 && h > 0 && pw > 0 && ph > 0) {
         debugPrint(
             '[TerminalModel] Terminal resized to ${w}x$h (pixel: ${pw}x$ph)');
+
+        // Mark terminal view as ready and flush any buffered output on first valid resize.
+        if (!_terminalViewReady) {
+          _markViewReady();
+        }
 
         // This piece of code must be placed before the conditional check in order to initialize properly.
         onResizeExternal?.call(w, h, pw, ph);
@@ -203,25 +220,12 @@ class TerminalModel with ChangeNotifier {
     }
   }
 
-  static bool getSuccessFromEvt(Map<String, dynamic> evt) {
-    if (evt.containsKey('success')) {
-      final v = evt['success'];
-      if (v is bool) {
-        // Desktop and mobile
-        return v;
-      } else if (v is String) {
-        // Web
-        return v.toLowerCase() == 'true';
-      } else {
-        // Unexpected type, log and handle gracefully
-        debugPrint(
-            '[TerminalModel] Unexpected success type: ${v.runtimeType}, value: $v. Expected bool or String.');
-        return false;
-      }
-    } else {
-      debugPrint('[TerminalModel] Event does not contain success');
-      return false;
-    }
+  /// Parse a boolean value from event map, handling both bool and String types (for web compatibility).
+  static bool getBoolFromEvt(Map<String, dynamic> evt, String key, {bool defaultValue = false}) {
+    final v = evt[key];
+    if (v is bool) return v;
+    if (v is String) return v.toLowerCase() == 'true';
+    return defaultValue;
   }
 
   void handleTerminalResponse(Map<String, dynamic> evt) {
@@ -252,17 +256,25 @@ class TerminalModel with ChangeNotifier {
   }
 
   void _handleTerminalOpened(Map<String, dynamic> evt) {
-    final bool success = getSuccessFromEvt(evt);
+    final bool success = getBoolFromEvt(evt, 'success');
     final String message = evt['message'] ?? '';
     final String? serviceId = evt['service_id'];
+    final bool reconnected = getBoolFromEvt(evt, 'reconnected');
 
     debugPrint(
-        '[TerminalModel] Terminal opened response: success=$success, message=$message, service_id=$serviceId');
+        '[TerminalModel] Terminal opened response: success=$success, message=$message, service_id=$serviceId, reconnected=$reconnected');
 
     if (success) {
       _terminalOpened = true;
 
       // Service ID is now saved on the Rust side in handle_terminal_response
+
+      // If this is a reconnection to an existing terminal, request the buffer
+      if (reconnected) {
+        debugPrint(
+            '[TerminalModel] Reconnected to existing terminal, requesting buffer');
+        _requestTerminalBuffer();
+      }
 
       // Process any buffered input
       _processBufferedInputAsync().then((_) {
@@ -327,11 +339,52 @@ class TerminalModel with ChangeNotifier {
           return;
         }
 
+        // Buffer data if terminal view is not ready yet to avoid NaN errors.
+        if (!_terminalViewReady) {
+          _pendingOutputChunks.add(text);
+          _pendingOutputSize += text.length;
+          // Drop oldest chunks if exceeds limit (whole chunks to preserve ANSI sequences)
+          while (_pendingOutputSize > _kMaxOutputBufferChars && _pendingOutputChunks.length > 1) {
+            final removed = _pendingOutputChunks.removeAt(0);
+            _pendingOutputSize -= removed.length;
+          }
+          return;
+        }
+
         terminal.write(text);
       } catch (e) {
         debugPrint('[TerminalModel] Failed to process terminal data: $e');
       }
     }
+  }
+
+  void _flushOutputBuffer() {
+    if (_pendingOutputChunks.isEmpty) return;
+    debugPrint('[TerminalModel] Flushing $_pendingOutputSize buffered chars (${_pendingOutputChunks.length} chunks)');
+    for (final chunk in _pendingOutputChunks) {
+      terminal.write(chunk);
+    }
+    _pendingOutputChunks.clear();
+    _pendingOutputSize = 0;
+  }
+
+  /// Mark terminal view as ready and flush buffered output.
+  void _markViewReady() {
+    if (_terminalViewReady) return;
+    _terminalViewReady = true;
+    _flushOutputBuffer();
+  }
+
+  /// Request terminal buffer from server (fire-and-forget with error logging).
+  void _requestTerminalBuffer() {
+    if (_disposed) return;
+    bind.sessionRequestTerminalBuffer(
+      sessionId: parent.sessionId,
+      terminalId: terminalId,
+      maxBytes: _kMaxRequestBufferBytes,
+    ).catchError((e) {
+      debugPrint('[TerminalModel] Error requesting terminal buffer: $e');
+    });
   }
 
   void _handleTerminalClosed(Map<String, dynamic> evt) {
@@ -350,6 +403,10 @@ class TerminalModel with ChangeNotifier {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    // Clear buffers to free memory
+    _inputBuffer.clear();
+    _pendingOutputChunks.clear();
+    _pendingOutputSize = 0;
     // Terminal cleanup is handled server-side when service closes
     super.dispose();
   }

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1984,6 +1984,21 @@ class RustdeskImpl {
         ]));
   }
 
+  Future<void> sessionRequestTerminalBuffer(
+      {required UuidValue sessionId,
+      required int terminalId,
+      required int maxBytes,
+      dynamic hint}) {
+    return Future(() => js.context.callMethod('setByName', [
+          'request_terminal_buffer',
+          jsonEncode({
+            'session_id': sessionId.toString(),
+            'terminal_id': terminalId,
+            'max_bytes': maxBytes,
+          })
+        ]));
+  }
+
   Future<int?> sessionGetEdgeScrollEdgeThickness(
       {required UuidValue sessionId, dynamic hint}) {
     final thickness = js.context.callMethod(

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1135,6 +1135,7 @@ impl InvokeUiSession for FlutterHandler {
                     ("message", json!(&opened.message)),
                     ("pid", json!(opened.pid)),
                     ("service_id", json!(&opened.service_id)),
+                    ("reconnected", json!(opened.reconnected)),
                 ];
                 if !opened.persistent_sessions.is_empty() {
                     event_data.push(("persistent_sessions", json!(opened.persistent_sessions)));

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -685,6 +685,17 @@ pub fn session_close_terminal(session_id: SessionID, terminal_id: i32) {
     }
 }
 
+pub fn session_request_terminal_buffer(session_id: SessionID, terminal_id: i32, max_bytes: u32) {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.request_terminal_buffer(terminal_id, max_bytes);
+    } else {
+        log::debug!(
+            "session_request_terminal_buffer: session not found for {:?}",
+            session_id
+        );
+    }
+}
+
 pub fn session_peer_option(session_id: SessionID, name: String, value: String) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.set_option(name, value);

--- a/src/server/terminal_service.rs
+++ b/src/server/terminal_service.rs
@@ -30,8 +30,20 @@ const MAX_OUTPUT_BUFFER_SIZE: usize = 1024 * 1024; // 1MB per terminal
 const MAX_BUFFER_LINES: usize = 10000;
 const MAX_SERVICES: usize = 100; // Maximum number of persistent terminal services
 const SERVICE_IDLE_TIMEOUT: Duration = Duration::from_secs(3600); // 1 hour idle timeout
-const CHANNEL_BUFFER_SIZE: usize = 100; // Number of messages to buffer in channel
+const CHANNEL_BUFFER_SIZE: usize = 500; // Number of messages to buffer in channel (increased to reduce data loss)
 const COMPRESS_THRESHOLD: usize = 512; // Compress terminal data larger than this
+                                       // Default max bytes for buffer request.
+const DEFAULT_REQUEST_BUFFER_BYTES: usize = 8 * 1024;
+
+/// Session state machine for terminal streaming.
+#[derive(Clone)]
+enum SessionState {
+    /// Session is closed, not streaming data to client.
+    Closed,
+    /// Session is active, streaming data to client.
+    /// pending_buffer: historical buffer to send before real-time data (set on reconnection).
+    Active { pending_buffer: Option<Vec<u8>> },
+}
 
 lazy_static::lazy_static! {
     // Global registry of persistent terminal services indexed by service_id
@@ -433,16 +445,23 @@ impl OutputBuffer {
     }
 
     fn get_recent(&self, max_bytes: usize) -> Vec<u8> {
-        let mut result = Vec::new();
+        let mut chunks: Vec<&[u8]> = Vec::new();
         let mut size = 0;
 
-        // Get recent lines up to max_bytes
+        // Collect chunks from newest to oldest (whole chunks only to avoid ANSI truncation)
         for line in self.lines.iter().rev() {
             if size + line.len() > max_bytes {
                 break;
             }
             size += line.len();
-            result.splice(0..0, line.iter().cloned());
+            chunks.push(line);
+        }
+
+        // Reverse to restore chronological order and concatenate
+        chunks.reverse();
+        let mut result = Vec::with_capacity(size);
+        for chunk in chunks {
+            result.extend_from_slice(chunk);
         }
 
         result
@@ -469,7 +488,8 @@ pub struct TerminalSession {
     cols: u16,
     // Track if we've already sent the closed message
     closed_message_sent: bool,
-    is_opened: bool,
+    // Session state machine for reconnection handling
+    state: SessionState,
     // Helper mode: PTY is managed by helper process, communication via message protocol
     #[cfg(target_os = "windows")]
     is_helper_mode: bool,
@@ -496,7 +516,7 @@ impl TerminalSession {
             rows,
             cols,
             closed_message_sent: false,
-            is_opened: false,
+            state: SessionState::Closed,
             #[cfg(target_os = "windows")]
             is_helper_mode: false,
             #[cfg(target_os = "windows")]
@@ -511,7 +531,7 @@ impl TerminalSession {
     // This helper function is to ensure that the threads are joined before the child process is dropped.
     // Though this is not strictly necessary on macOS.
     fn stop(&mut self) {
-        self.is_opened = false;
+        self.state = SessionState::Closed;
         self.exiting.store(true, Ordering::SeqCst);
 
         // Drop the input channel to signal writer thread to exit
@@ -683,7 +703,7 @@ impl PersistentTerminalService {
         self.needs_session_sync = true;
         for session in self.sessions.values() {
             let mut session = session.lock().unwrap();
-            session.is_opened = false;
+            session.state = SessionState::Closed;
         }
     }
 }
@@ -766,6 +786,15 @@ impl TerminalServiceProxy {
             Some(terminal_action::Union::Close(close)) => {
                 self.handle_close(&mut service.lock().unwrap(), close)
             }
+            Some(terminal_action::Union::RequestBuffer(req)) => {
+                let session = service
+                    .lock()
+                    .unwrap()
+                    .sessions
+                    .get(&req.terminal_id)
+                    .cloned();
+                self.handle_request_buffer(session, &req)
+            }
             _ => Ok(None),
         }
     }
@@ -781,11 +810,23 @@ impl TerminalServiceProxy {
         if let Some(session_arc) = service.sessions.get(&open.terminal_id) {
             // Reconnect to existing terminal
             let mut session = session_arc.lock().unwrap();
-            session.is_opened = true;
+            // Directly enter Active state with pending buffer for immediate streaming.
+            // Historical buffer is sent first by read_outputs(), then real-time data follows.
+            let buffer = session
+                .output_buffer
+                .get_recent(DEFAULT_REQUEST_BUFFER_BYTES);
+            session.state = SessionState::Active {
+                pending_buffer: if buffer.is_empty() {
+                    None
+                } else {
+                    Some(buffer)
+                },
+            };
             let mut opened = TerminalOpened::new();
             opened.terminal_id = open.terminal_id;
             opened.success = true;
             opened.message = "Reconnected to existing terminal".to_string();
+            opened.reconnected = true;
             opened.pid = session.pid;
             opened.service_id = self.service_id.clone();
             if service.needs_session_sync {
@@ -802,13 +843,6 @@ impl TerminalServiceProxy {
                 service.needs_session_sync = false;
             }
             response.set_opened(opened);
-
-            // Send buffered output
-            let buffer = session.output_buffer.get_recent(4096);
-            if !buffer.is_empty() {
-                // We'll need to send this separately or extend the protocol
-                // For now, just acknowledge the reconnection
-            }
 
             return Ok(Some(response));
         }
@@ -932,19 +966,12 @@ impl TerminalServiceProxy {
                             break;
                         }
                         let data = buf[..n].to_vec();
-                        // Try to send, if channel is full, drop the data
-                        match output_tx.try_send(data) {
-                            Ok(_) => {}
-                            Err(mpsc::TrySendError::Full(_)) => {
-                                log::debug!(
-                                    "Terminal {} output channel full, dropping data",
-                                    terminal_id
-                                );
-                            }
-                            Err(mpsc::TrySendError::Disconnected(_)) => {
-                                log::debug!("Terminal {} output channel disconnected", terminal_id);
-                                break;
-                            }
+                        // Use blocking send to prevent data loss.
+                        // Channel buffer (500) provides enough headroom for normal operation.
+                        // If channel is full, blocking is preferred over dropping data.
+                        if let Err(_) = output_tx.send(data) {
+                            log::debug!("Terminal {} output channel disconnected", terminal_id);
+                            break;
                         }
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -970,7 +997,9 @@ impl TerminalServiceProxy {
         session.output_rx = Some(output_rx);
         session.reader_thread = Some(reader_thread);
         session.writer_thread = Some(writer_thread);
-        session.is_opened = true;
+        session.state = SessionState::Active {
+            pending_buffer: None,
+        };
 
         let mut opened = TerminalOpened::new();
         opened.terminal_id = open.terminal_id;
@@ -1144,18 +1173,10 @@ impl TerminalServiceProxy {
                             break;
                         }
                         let data = buf[..n].to_vec();
-                        match output_tx.try_send(data) {
-                            Ok(_) => {}
-                            Err(mpsc::TrySendError::Full(_)) => {
-                                log::debug!(
-                                    "Terminal {} output channel full, dropping data",
-                                    terminal_id
-                                );
-                            }
-                            Err(mpsc::TrySendError::Disconnected(_)) => {
-                                log::debug!("Terminal {} output channel disconnected", terminal_id);
-                                break;
-                            }
+                        // Use blocking send to prevent data loss (same as direct PTY mode)
+                        if let Err(_) = output_tx.send(data) {
+                            log::debug!("Terminal {} output channel disconnected", terminal_id);
+                            break;
                         }
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1185,7 +1206,9 @@ impl TerminalServiceProxy {
         session.output_rx = Some(output_rx);
         session.reader_thread = Some(reader_thread);
         session.writer_thread = Some(writer_thread);
-        session.is_opened = true;
+        session.state = SessionState::Active {
+            pending_buffer: None,
+        };
         session.is_helper_mode = true;
         session.helper_process_handle = Some(SendableHandle::new(helper_raw_handle));
 
@@ -1332,6 +1355,45 @@ impl TerminalServiceProxy {
         }
     }
 
+    fn handle_request_buffer(
+        &self,
+        session: Option<Arc<Mutex<TerminalSession>>>,
+        req: &RequestTerminalBuffer,
+    ) -> Result<Option<TerminalResponse>> {
+        // No-op: buffer is now sent automatically on reconnection (in handle_open).
+        // This handler is kept for backward compatibility with older clients.
+        if session.is_none() {
+            log::warn!(
+                "Terminal {} not found for buffer request in service {}",
+                req.terminal_id,
+                self.service_id
+            );
+        }
+        Ok(None)
+    }
+
+    /// Helper to create a TerminalResponse with optional compression.
+    fn create_terminal_data_response(terminal_id: i32, data: Vec<u8>) -> TerminalResponse {
+        let mut response = TerminalResponse::new();
+        let mut terminal_data = TerminalData::new();
+        terminal_data.terminal_id = terminal_id;
+
+        if data.len() > COMPRESS_THRESHOLD {
+            let compressed = compress::compress(&data);
+            if compressed.len() < data.len() {
+                terminal_data.data = bytes::Bytes::from(compressed);
+                terminal_data.compressed = true;
+            } else {
+                terminal_data.data = bytes::Bytes::from(data);
+            }
+        } else {
+            terminal_data.data = bytes::Bytes::from(data);
+        }
+
+        response.set_data(terminal_data);
+        response
+    }
+
     pub fn read_outputs(&self) -> Vec<TerminalResponse> {
         let service = match get_service(&self.service_id) {
             Some(s) => s,
@@ -1373,12 +1435,8 @@ impl TerminalServiceProxy {
                     closed_terminals.push(terminal_id);
                 }
 
-                if !session.is_opened {
-                    // Skip the session if it is not opened.
-                    continue;
-                }
-
-                // Read from output channel
+                // Read from output channel (always read to prevent channel overflow,
+                // even when session is not opened - data will be buffered for reconnection)
                 let mut has_activity = false;
                 let mut received_data = Vec::new();
                 if let Some(output_rx) = &session.output_rx {
@@ -1389,37 +1447,33 @@ impl TerminalServiceProxy {
                     }
                 }
 
-                // Update buffer after reading
+                if has_activity {
+                    session.update_activity();
+                }
+
+                // Update buffer (always buffer for reconnection support)
                 for data in &received_data {
                     session.output_buffer.append(data);
                 }
 
-                // Process received data for responses
-                for data in received_data {
-                    let mut response = TerminalResponse::new();
-                    let mut terminal_data = TerminalData::new();
-                    terminal_data.terminal_id = terminal_id;
+                // Skip sending responses if session is not Active.
+                // Data is already buffered above and will be sent on next reconnection.
+                let pending_buffer = match &mut session.state {
+                    SessionState::Active { pending_buffer } => pending_buffer,
+                    _ => continue,
+                };
 
-                    // Compress data if it exceeds threshold
-                    if data.len() > COMPRESS_THRESHOLD {
-                        let compressed = compress::compress(&data);
-                        if compressed.len() < data.len() {
-                            terminal_data.data = bytes::Bytes::from(compressed);
-                            terminal_data.compressed = true;
-                        } else {
-                            // Compression didn't help, send uncompressed
-                            terminal_data.data = bytes::Bytes::from(data);
-                        }
-                    } else {
-                        terminal_data.data = bytes::Bytes::from(data);
+                // Send pending buffer response first (set on reconnection in handle_open).
+                // This ensures historical buffer is sent before any real-time data.
+                if let Some(buffer) = pending_buffer.take() {
+                    if !buffer.is_empty() {
+                        responses.push(Self::create_terminal_data_response(terminal_id, buffer));
                     }
-
-                    response.set_data(terminal_data);
-                    responses.push(response);
                 }
 
-                if has_activity {
-                    session.update_activity();
+                // Send real-time data after historical buffer
+                for data in received_data {
+                    responses.push(Self::create_terminal_data_response(terminal_id, data));
                 }
             }
         }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -833,6 +833,18 @@ impl<T: InvokeUiSession> Session<T> {
         self.send(Data::Message(msg_out));
     }
 
+    pub fn request_terminal_buffer(&self, terminal_id: i32, max_bytes: u32) {
+        let mut action = TerminalAction::new();
+        action.set_request_buffer(RequestTerminalBuffer {
+            terminal_id,
+            max_bytes,
+            ..Default::default()
+        });
+        let mut msg_out = Message::new();
+        msg_out.set_terminal_action(action);
+        self.send(Data::Message(msg_out));
+    }
+
     pub fn capture_displays(&self, add: Vec<i32>, sub: Vec<i32>, set: Vec<i32>) {
         let mut misc = Misc::new();
         misc.set_capture_displays(CaptureDisplays {


### PR DESCRIPTION
  - Fix tab close not preserving persistent sessions: check isPersistent flag before sending CloseTerminal message to server
  - Fix new tab not auto-focusing: add FocusNode to TerminalView and request focus when tab is selected
  - Fix NaN error when data arrives before terminal view layout: buffer output data until terminal view has valid dimensions
  - Add RequestTerminalBuffer support for reconnection: request buffered output from server when reconnecting to persistent session to avoid blank screen

  Fixes issues:
  1. Tab close vs window close persistence behavior inconsistency
  2. New tabs require mouse click to accept keyboard input
  3. Reconnecting to persistent sessions shows blank screen
  4. Multi-tab session confusion after closing tabs (same root cause as #1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request recent terminal output on demand.

* **Improvements**
  * More reliable keyboard focus and autofocus when switching to terminal tabs.
  * Buffered output handling during startup and reconnection to avoid lost data.
  * Unified tab-close flow to prevent overlapping closes.

* **Bug Fixes**
  * Consistent tab-close behavior that respects persistent-mode terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->