### PR TITLE
ipc: restrict local access and protect service channel

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -39,7 +39,7 @@ use hbb_common::{
 
 use crate::{
     hbbs_http::{create_http_client_async, get_url_for_tls},
-    ui_interface::{get_option, is_installed, set_option},
+    ui_interface::{get_option, set_option},
 };
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -83,7 +83,7 @@ fn is_allowed_windows_service_peer(
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[inline]
-fn is_allowed_service_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
+pub(crate) fn is_allowed_service_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
     peer_uid == 0 || active_uid.is_some_and(|uid| uid == peer_uid)
 }
 
@@ -130,7 +130,7 @@ struct ActiveUidCacheEntry {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[inline]
-fn active_uid_cached() -> Option<u32> {
+pub(crate) fn active_uid_cached() -> Option<u32> {
     static ACTIVE_UID_CACHE: OnceLock<Mutex<Option<ActiveUidCacheEntry>>> = OnceLock::new();
     let cache = ACTIVE_UID_CACHE.get_or_init(|| Mutex::new(None));
     let now = std::time::Instant::now();
@@ -149,6 +149,39 @@ fn active_uid_cached() -> Option<u32> {
             uid
         }
         Err(_) => active_uid_strict(),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[inline]
+pub(crate) fn peer_uid_from_fd(fd: std::os::unix::io::RawFd) -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut cred: hbb_common::libc::ucred = unsafe { std::mem::zeroed() };
+        let mut len = std::mem::size_of::<hbb_common::libc::ucred>() as hbb_common::libc::socklen_t;
+        let rc = unsafe {
+            hbb_common::libc::getsockopt(
+                fd,
+                hbb_common::libc::SOL_SOCKET,
+                hbb_common::libc::SO_PEERCRED,
+                &mut cred as *mut _ as *mut hbb_common::libc::c_void,
+                &mut len,
+            )
+        };
+        if rc == 0 {
+            return Some(cred.uid as u32);
+        }
+        return None;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut uid: hbb_common::libc::uid_t = 0;
+        let mut gid: hbb_common::libc::gid_t = 0;
+        if unsafe { hbb_common::libc::getpeereid(fd, &mut uid, &mut gid) } == 0 {
+            Some(uid as u32)
+        } else {
+            None
+        }
     }
 }
 
@@ -200,7 +233,7 @@ fn log_rejected_service_connection(postfix: &str, peer_uid: Option<u32>, active_
     throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
         if suppressed > 0 {
             log::warn!(
-                "Rejected unauthorized connection on protected ipc_service channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
+                "Rejected unauthorized connection on protected service-scoped IPC channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
                 postfix,
                 peer_uid,
                 active_uid,
@@ -208,7 +241,7 @@ fn log_rejected_service_connection(postfix: &str, peer_uid: Option<u32>, active_
             );
         } else {
             log::warn!(
-                "Rejected unauthorized connection on protected ipc_service channel: postfix={}, peer_uid={:?}, active_uid={:?}",
+                "Rejected unauthorized connection on protected service-scoped IPC channel: postfix={}, peer_uid={:?}, active_uid={:?}",
                 postfix,
                 peer_uid,
                 active_uid
@@ -900,7 +933,7 @@ pub async fn start(postfix: &str) -> ResultType<()> {
                                             handle(data, &mut stream).await;
                                         } else {
                                             log::warn!(
-                                                "Rejected non-sync data on protected ipc_service channel: postfix={}, data_kind={:?}, peer_uid={:?}",
+                                                "Rejected non-sync data on protected _service IPC channel: postfix={}, data_kind={:?}, peer_uid={:?}",
                                                 postfix,
                                                 std::mem::discriminant(&data),
                                                 stream.peer_uid()
@@ -1705,39 +1738,10 @@ pub fn get_permanent_password() -> String {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 impl<T> ConnectionTmpl<T>
 where
-    T: AsyncRead + AsyncWrite + std::marker::Unpin + std::os::fd::AsRawFd,
+    T: AsyncRead + AsyncWrite + std::marker::Unpin + std::os::unix::io::AsRawFd,
 {
     fn peer_uid(&self) -> Option<u32> {
-        let fd = self.inner.get_ref().as_raw_fd();
-        #[cfg(target_os = "linux")]
-        {
-            let mut cred: hbb_common::libc::ucred = unsafe { std::mem::zeroed() };
-            let mut len =
-                std::mem::size_of::<hbb_common::libc::ucred>() as hbb_common::libc::socklen_t;
-            let rc = unsafe {
-                hbb_common::libc::getsockopt(
-                    fd,
-                    hbb_common::libc::SOL_SOCKET,
-                    hbb_common::libc::SO_PEERCRED,
-                    &mut cred as *mut _ as *mut hbb_common::libc::c_void,
-                    &mut len,
-                )
-            };
-            if rc == 0 {
-                return Some(cred.uid as u32);
-            }
-            return None;
-        }
-        #[cfg(target_os = "macos")]
-        {
-            let mut uid: hbb_common::libc::uid_t = 0;
-            let mut gid: hbb_common::libc::gid_t = 0;
-            if unsafe { hbb_common::libc::getpeereid(fd, &mut uid, &mut gid) } == 0 {
-                Some(uid as u32)
-            } else {
-                None
-            }
-        }
+        peer_uid_from_fd(self.inner.get_ref().as_raw_fd())
     }
 
     fn service_authorization_status(&self) -> (bool, Option<u32>, Option<u32>) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,33 +1,20 @@
+#[cfg(all(feature = "flutter", feature = "plugin_framework"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::plugin::ipc::Plugin;
 use crate::{
     common::CheckTestNatType,
     privacy_mode::PrivacyModeState,
     ui_interface::{get_local_option, set_local_option},
 };
 use bytes::Bytes;
-use parity_tokio_ipc::{
-    Connection as Conn, ConnectionClient as ConnClient, Endpoint, Incoming, SecurityAttributes,
-};
-use serde_derive::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    sync::atomic::{AtomicBool, Ordering},
-};
-#[cfg(not(windows))]
-use std::{fs::File, io::prelude::*};
-
-#[cfg(all(feature = "flutter", feature = "plugin_framework"))]
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-use crate::plugin::ipc::Plugin;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use clipboard::ClipboardFile;
+#[cfg(target_os = "linux")]
+use hbb_common::anyhow;
 use hbb_common::{
     allow_err, bail, bytes,
     bytes_codec::BytesCodec,
-    config::{
-        self,
-        keys::{self, OPTION_ALLOW_WEBSOCKET},
-        Config, Config2,
-    },
+    config::{self, keys::OPTION_ALLOW_WEBSOCKET, Config, Config2},
     futures::StreamExt as _,
     futures_util::sink::SinkExt,
     log, password_security as password, timeout,
@@ -38,12 +25,475 @@ use hbb_common::{
     tokio_util::codec::Framed,
     ResultType,
 };
+use parity_tokio_ipc::{
+    Connection as Conn, ConnectionClient as ConnClient, Endpoint, Incoming, SecurityAttributes,
+};
+use serde_derive::{Deserialize, Serialize};
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, OnceLock,
+    },
+};
+#[cfg(unix)]
+use std::{
+    ffi::CString,
+    fs::File,
+    io::{prelude::*, Error, ErrorKind},
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{MetadataExt, PermissionsExt},
+    },
+    path::Path,
+};
+#[cfg(windows)]
+use windows::Win32::{Foundation::HANDLE, System::Pipes::GetNamedPipeClientProcessId};
 
 use crate::{common::is_server, privacy_mode, rendezvous_mediator::RendezvousMediator};
 
 // IPC actions here.
 pub const IPC_ACTION_CLOSE: &str = "close";
 pub static EXIT_RECV_CLOSE: AtomicBool = AtomicBool::new(true);
+
+#[cfg(windows)]
+#[inline]
+fn is_allowed_windows_server_peer(
+    client_is_system: bool,
+    client_session_id: Option<u32>,
+    server_session_id: Option<u32>,
+) -> bool {
+    client_is_system || (client_session_id.is_some() && client_session_id == server_session_id)
+}
+
+#[cfg(windows)]
+#[inline]
+fn is_allowed_windows_service_peer(
+    client_is_system: bool,
+    client_session_id: Option<u32>,
+    expected_active_session_id: Option<u32>,
+) -> bool {
+    client_is_system
+        || (expected_active_session_id.is_some()
+            && client_session_id.is_some()
+            && client_session_id == expected_active_session_id)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[inline]
+fn is_allowed_service_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
+    peer_uid == 0 || active_uid.is_some_and(|uid| uid == peer_uid)
+}
+
+#[cfg(target_os = "macos")]
+#[inline]
+fn console_owner_uid() -> Option<u32> {
+    std::fs::metadata("/dev/console")
+        .ok()
+        .map(|metadata| metadata.uid())
+}
+
+#[cfg(target_os = "macos")]
+#[inline]
+fn active_uid_strict() -> Option<u32> {
+    // Prefer the filesystem metadata over parsing external command output.
+    console_owner_uid()
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn active_uid_strict() -> Option<u32> {
+    let reported_uid_raw = crate::platform::linux::get_active_userid();
+    let trimmed = reported_uid_raw.trim();
+    if let Ok(uid) = trimmed.parse::<u32>() {
+        return Some(uid);
+    }
+    if trimmed.is_empty() {
+        log::debug!("Failed to resolve active user uid on linux: active uid is empty");
+    } else {
+        log::warn!("Failed to parse active user uid on linux: '{}'", trimmed);
+    }
+    None
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const ACTIVE_UID_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[derive(Clone, Copy)]
+struct ActiveUidCacheEntry {
+    uid: Option<u32>,
+    cached_at: std::time::Instant,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[inline]
+fn active_uid_cached() -> Option<u32> {
+    static ACTIVE_UID_CACHE: OnceLock<Mutex<Option<ActiveUidCacheEntry>>> = OnceLock::new();
+    let cache = ACTIVE_UID_CACHE.get_or_init(|| Mutex::new(None));
+    let now = std::time::Instant::now();
+    match cache.lock() {
+        Ok(mut cache) => {
+            if let Some(entry) = *cache {
+                if now.saturating_duration_since(entry.cached_at) < ACTIVE_UID_CACHE_TTL {
+                    return entry.uid;
+                }
+            }
+            let uid = active_uid_strict();
+            *cache = Some(ActiveUidCacheEntry {
+                uid,
+                cached_at: now,
+            });
+            uid
+        }
+        Err(_) => active_uid_strict(),
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+const UNAUTHORIZED_IPC_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+#[derive(Default)]
+struct UnauthorizedIpcLogThrottle {
+    last_log_at: Option<std::time::Instant>,
+    suppressed: u64,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+impl UnauthorizedIpcLogThrottle {
+    #[inline]
+    fn on_reject(&mut self, now: std::time::Instant) -> Option<u64> {
+        if let Some(last) = self.last_log_at {
+            if now.saturating_duration_since(last) < UNAUTHORIZED_IPC_LOG_INTERVAL {
+                self.suppressed += 1;
+                return None;
+            }
+        }
+        self.last_log_at = Some(now);
+        Some(std::mem::take(&mut self.suppressed))
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+#[inline]
+fn throttled_unauthorized_ipc_log(
+    throttle_cell: &OnceLock<Mutex<UnauthorizedIpcLogThrottle>>,
+    emit: impl FnOnce(u64),
+) {
+    let throttle = throttle_cell.get_or_init(|| Mutex::new(UnauthorizedIpcLogThrottle::default()));
+    let should_log = match throttle.lock() {
+        Ok(mut throttle) => throttle.on_reject(std::time::Instant::now()),
+        Err(_) => Some(0),
+    };
+    if let Some(suppressed) = should_log {
+        emit(suppressed);
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[inline]
+fn log_rejected_service_connection(postfix: &str, peer_uid: Option<u32>, active_uid: Option<u32>) {
+    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
+    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
+        if suppressed > 0 {
+            log::warn!(
+                "Rejected unauthorized connection on protected ipc_service channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
+                postfix,
+                peer_uid,
+                active_uid,
+                suppressed
+            );
+        } else {
+            log::warn!(
+                "Rejected unauthorized connection on protected ipc_service channel: postfix={}, peer_uid={:?}, active_uid={:?}",
+                postfix,
+                peer_uid,
+                active_uid
+            );
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+pub(crate) fn log_rejected_uinput_connection(
+    postfix: &str,
+    peer_uid: Option<u32>,
+    active_uid: Option<u32>,
+) {
+    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
+    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
+        if suppressed > 0 {
+            log::warn!(
+                "Rejected unauthorized connection on uinput ipc channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
+                postfix,
+                peer_uid,
+                active_uid,
+                suppressed
+            );
+        } else {
+            log::warn!(
+                "Rejected unauthorized connection on uinput ipc channel: postfix={}, peer_uid={:?}, active_uid={:?}",
+                postfix,
+                peer_uid,
+                active_uid
+            );
+        }
+    });
+}
+
+#[cfg(windows)]
+#[inline]
+pub(crate) fn log_rejected_windows_ipc_connection(
+    postfix: &str,
+    peer_pid: Option<u32>,
+    peer_session_id: Option<u32>,
+    expected_session_id: Option<u32>,
+    peer_is_system: Option<bool>,
+) {
+    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
+    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
+        if suppressed > 0 {
+            log::warn!(
+                "Rejected unauthorized connection on ipc channel: postfix={}, peer_pid={:?}, peer_session_id={:?}, expected_session_id={:?}, peer_is_system={:?} (suppressed {} similar events)",
+                postfix,
+                peer_pid,
+                peer_session_id,
+                expected_session_id,
+                peer_is_system,
+                suppressed
+            );
+        } else {
+            log::warn!(
+                "Rejected unauthorized connection on ipc channel: postfix={}, peer_pid={:?}, peer_session_id={:?}, expected_session_id={:?}, peer_is_system={:?}",
+                postfix,
+                peer_pid,
+                peer_session_id,
+                expected_session_id,
+                peer_is_system
+            );
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn terminal_count_candidate_uids(effective_uid: u32) -> Vec<u32> {
+    if effective_uid != 0 {
+        return vec![effective_uid];
+    }
+    let mut candidates = Vec::with_capacity(2);
+    if let Some(uid) = active_uid_cached().filter(|uid| *uid != 0) {
+        candidates.push(uid);
+    }
+    candidates.push(0);
+    candidates
+}
+
+#[cfg(unix)]
+#[inline]
+fn expected_ipc_parent_mode(postfix: &str) -> u32 {
+    if config::is_service_ipc_postfix(postfix) {
+        0o0711
+    } else {
+        0o0700
+    }
+}
+
+#[cfg(unix)]
+fn open_ipc_parent_dir_fd(parent_c: &CString) -> std::io::Result<i32> {
+    let fd = unsafe {
+        hbb_common::libc::open(
+            parent_c.as_ptr(),
+            hbb_common::libc::O_RDONLY
+                | hbb_common::libc::O_DIRECTORY
+                | hbb_common::libc::O_CLOEXEC
+                | hbb_common::libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(fd)
+    }
+}
+
+#[cfg(unix)]
+fn ensure_secure_ipc_parent_dir(path: &str, postfix: &str) -> ResultType<()> {
+    let parent_dir = Path::new(path)
+        .parent()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, format!("invalid ipc path: {path}")))?;
+    // Harden against common TOCTOU by opening the parent directory with O_NOFOLLOW (so the parent
+    // itself cannot be a symlink) and then operating on its FD (fstat/fchown/fchmod). This ensures
+    // we mutate the inode we opened, though it does not protect against symlinks in ancestor path
+    // components.
+    let parent_c = CString::new(parent_dir.as_os_str().as_bytes().to_vec())?;
+    let fd = match open_ipc_parent_dir_fd(&parent_c) {
+        Ok(fd) => fd,
+        Err(open_err) => {
+            // If the directory doesn't exist yet, create it with the expected mode. The parent
+            // dir is intended to be a single-level /tmp path, so mkdir is sufficient here.
+            if open_err.raw_os_error() == Some(hbb_common::libc::ENOENT) {
+                let expected_mode = expected_ipc_parent_mode(postfix);
+                let rc = unsafe {
+                    hbb_common::libc::mkdir(
+                        parent_c.as_ptr(),
+                        expected_mode as hbb_common::libc::mode_t,
+                    )
+                };
+                if rc != 0 {
+                    let mkdir_err = std::io::Error::last_os_error();
+                    // Handle a race where another process created the directory first.
+                    if mkdir_err.raw_os_error() != Some(hbb_common::libc::EEXIST) {
+                        return Err(Error::new(
+                            mkdir_err.kind(),
+                            format!(
+                                "failed to mkdir ipc parent dir: postfix={}, parent={}, err={}",
+                                postfix,
+                                parent_dir.display(),
+                                mkdir_err
+                            ),
+                        )
+                        .into());
+                    }
+                }
+                match open_ipc_parent_dir_fd(&parent_c) {
+                    Ok(fd) => fd,
+                    Err(err) => {
+                        return Err(Error::new(
+                            err.kind(),
+                            format!(
+                                "failed to open ipc parent dir (no-follow): postfix={}, parent={}, err={}",
+                                postfix,
+                                parent_dir.display(),
+                                err
+                            ),
+                        )
+                        .into());
+                    }
+                }
+            } else {
+                return Err(Error::new(
+                    open_err.kind(),
+                    format!(
+                        "failed to open ipc parent dir (no-follow): postfix={}, parent={}, err={}",
+                        postfix,
+                        parent_dir.display(),
+                        open_err
+                    ),
+                )
+                .into());
+            }
+        }
+    };
+    struct FdGuard(i32);
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            unsafe {
+                hbb_common::libc::close(self.0);
+            }
+        }
+    }
+    let _fd_guard = FdGuard(fd);
+
+    let mut st: hbb_common::libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { hbb_common::libc::fstat(fd, &mut st as *mut _) } != 0 {
+        let os_err = std::io::Error::last_os_error();
+        return Err(Error::new(
+            os_err.kind(),
+            format!(
+                "failed to stat ipc parent dir: postfix={}, parent={}, err={}",
+                postfix,
+                parent_dir.display(),
+                os_err
+            ),
+        )
+        .into());
+    }
+    let mode = st.st_mode as u32;
+    let is_dir = (mode & (hbb_common::libc::S_IFMT as u32)) == (hbb_common::libc::S_IFDIR as u32);
+    if !is_dir {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            format!(
+                "ipc parent is not directory: postfix={}, parent={}",
+                postfix,
+                parent_dir.display()
+            ),
+        )
+        .into());
+    }
+
+    let expected_uid = unsafe { hbb_common::libc::geteuid() as u32 };
+    let mut owner_uid = st.st_uid as u32;
+    if owner_uid != expected_uid && expected_uid == 0 && config::is_service_ipc_postfix(postfix) {
+        let rc = unsafe {
+            hbb_common::libc::fchown(
+                fd,
+                expected_uid as hbb_common::libc::uid_t,
+                hbb_common::libc::gid_t::MAX,
+            )
+        };
+        if rc == 0 {
+            let mut st2: hbb_common::libc::stat = unsafe { std::mem::zeroed() };
+            if unsafe { hbb_common::libc::fstat(fd, &mut st2 as *mut _) } == 0 {
+                owner_uid = st2.st_uid as u32;
+                st = st2;
+            }
+        } else {
+            // Keep behavior unchanged; capture errno to ease diagnosing why chown failed.
+            let err = std::io::Error::last_os_error();
+            log::warn!(
+                "Failed to chown ipc parent dir, parent={}, postfix={}, expected_uid={}, rc={}, err={:?}",
+                parent_dir.display(),
+                postfix,
+                expected_uid,
+                rc,
+                err
+            );
+        }
+    }
+    if owner_uid != expected_uid {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            format!(
+                "unsafe ipc parent owner, postfix={}, expected uid {expected_uid}, got {owner_uid}: {}",
+                postfix,
+                parent_dir.display()
+            ),
+        )
+        .into());
+    }
+
+    let expected_mode = expected_ipc_parent_mode(postfix);
+    // Include special bits (setuid/setgid/sticky) to ensure the directory is hardened to the exact
+    // expected mode.
+    let current_mode = (st.st_mode as u32) & 0o7777;
+    if current_mode != expected_mode {
+        if unsafe { hbb_common::libc::fchmod(fd, expected_mode as hbb_common::libc::mode_t) } != 0 {
+            let os_err = std::io::Error::last_os_error();
+            return Err(Error::new(
+                os_err.kind(),
+                format!(
+                    "failed to chmod ipc parent dir: postfix={}, parent={}, err={}",
+                    postfix,
+                    parent_dir.display(),
+                    os_err
+                ),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+pub async fn connect_service(ms_timeout: u64) -> ResultType<ConnectionTmpl<ConnClient>> {
+    connect(ms_timeout, crate::POSTFIX_SERVICE).await
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "t", content = "c")]
@@ -403,6 +853,35 @@ pub async fn start(postfix: &str) -> ResultType<()> {
                 Ok(stream) => {
                     let mut stream = Connection::new(stream);
                     let postfix = postfix.to_owned();
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    if config::is_service_ipc_postfix(&postfix) {
+                        let (authorized, peer_uid, active_uid) =
+                            stream.service_authorization_status();
+                        if !authorized {
+                            log_rejected_service_connection(&postfix, peer_uid, active_uid);
+                            continue;
+                        }
+                    }
+                    #[cfg(windows)]
+                    if postfix.is_empty() {
+                        let (
+                            authorized,
+                            peer_pid,
+                            peer_session_id,
+                            server_session_id,
+                            peer_is_system,
+                        ) = stream.server_authorization_status();
+                        if !authorized {
+                            log_rejected_windows_ipc_connection(
+                                &postfix,
+                                peer_pid,
+                                peer_session_id,
+                                server_session_id,
+                                peer_is_system,
+                            );
+                            continue;
+                        }
+                    }
                     tokio::spawn(async move {
                         loop {
                             match stream.next().await {
@@ -411,6 +890,27 @@ pub async fn start(postfix: &str) -> ResultType<()> {
                                     break;
                                 }
                                 Ok(Some(data)) => {
+                                    // On Linux/macOS, the protected `_service` channel is used only for
+                                    // syncing config between root service and the active user process.
+                                    // Enforce a strict message allowlist here to keep the exposed surface
+                                    // minimal, even though we already authorize the peer at accept-time.
+                                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                                    if postfix == crate::POSTFIX_SERVICE {
+                                        if matches!(&data, Data::SyncConfig(_)) {
+                                            handle(data, &mut stream).await;
+                                        } else {
+                                            log::warn!(
+                                                "Rejected non-sync data on protected ipc_service channel: postfix={}, data_kind={:?}, peer_uid={:?}",
+                                                postfix,
+                                                std::mem::discriminant(&data),
+                                                stream.peer_uid()
+                                            );
+                                            // Close the connection to avoid keeping a protected channel
+                                            // alive while repeatedly receiving invalid traffic.
+                                            break;
+                                        }
+                                        continue;
+                                    }
                                     handle(data, &mut stream).await;
                                 }
                                 _ => {}
@@ -428,7 +928,9 @@ pub async fn start(postfix: &str) -> ResultType<()> {
 
 pub async fn new_listener(postfix: &str) -> ResultType<Incoming> {
     let path = Config::ipc_path(postfix);
-    #[cfg(not(any(windows, target_os = "android", target_os = "ios")))]
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "ios"))))]
+    ensure_secure_ipc_parent_dir(&path, postfix)?;
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "ios"))))]
     check_pid(postfix).await;
     let mut endpoint = Endpoint::new(path.clone());
     match SecurityAttributes::allow_everyone_create() {
@@ -437,11 +939,45 @@ pub async fn new_listener(postfix: &str) -> ResultType<Incoming> {
     };
     match endpoint.incoming() {
         Ok(incoming) => {
-            log::info!("Started ipc{} server at path: {}", postfix, &path);
-            #[cfg(not(windows))]
+            if postfix == crate::POSTFIX_SERVICE {
+                log::info!("Started protected ipc service server: postfix={}", postfix);
+            } else {
+                log::info!("Started ipc{} server at path: {}", postfix, &path);
+            }
+            #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o0777)).ok();
+                // NOTE: On Linux/macOS, some IPC sockets are intentionally world-connectable
+                // (0666) so the active (non-root) user process can connect. Authorization is
+                // enforced at accept-time for these channels, and the protected `_service`
+                // channel is further restricted by an explicit message allowlist (SyncConfig
+                // only). On other Unix targets, permissions are kept at 0600 unless equivalent
+                // authorization is implemented.
+                let socket_mode = if config::is_service_ipc_postfix(postfix) {
+                    // Align permission behavior with the platforms that enforce accept-time peer
+                    // authorization for the protected service channel.
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    {
+                        0o0666
+                    }
+                    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                    {
+                        0o0600
+                    }
+                } else {
+                    0o0600
+                };
+                if let Err(err) =
+                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(socket_mode))
+                {
+                    log::error!(
+                        "Failed to set permissions on ipc{} socket at path {}: {}",
+                        postfix,
+                        &path,
+                        err
+                    );
+                    std::fs::remove_file(&path).ok();
+                    return Err(err.into());
+                }
                 write_pid(postfix);
             }
             Ok(incoming)
@@ -896,13 +1432,28 @@ async fn handle(data: Data, stream: &mut Connection) {
             );
         }
         _ => {}
-    }
+    };
 }
 
 pub async fn connect(ms_timeout: u64, postfix: &str) -> ResultType<ConnectionTmpl<ConnClient>> {
     let path = Config::ipc_path(postfix);
-    let client = timeout(ms_timeout, Endpoint::connect(&path)).await??;
+    connect_with_path(ms_timeout, &path).await
+}
+
+#[inline]
+async fn connect_with_path(ms_timeout: u64, path: &str) -> ResultType<ConnectionTmpl<ConnClient>> {
+    let client = timeout(ms_timeout, Endpoint::connect(path)).await??;
     Ok(ConnectionTmpl::new(client))
+}
+
+#[cfg(target_os = "linux")]
+pub async fn connect_for_uid(
+    ms_timeout: u64,
+    uid: u32,
+    postfix: &str,
+) -> ResultType<ConnectionTmpl<ConnClient>> {
+    let path = Config::ipc_path_for_uid(uid, postfix);
+    connect_with_path(ms_timeout, &path).await
 }
 
 #[cfg(target_os = "linux")]
@@ -983,13 +1534,13 @@ pub async fn start_pa() {
 }
 
 #[inline]
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn get_pid_file(postfix: &str) -> String {
     let path = Config::ipc_path(postfix);
     format!("{}.pid", path)
 }
 
-#[cfg(not(any(windows, target_os = "android", target_os = "ios")))]
+#[cfg(all(unix, not(any(target_os = "android", target_os = "ios"))))]
 async fn check_pid(postfix: &str) {
     let pid_file = get_pid_file(postfix);
     if let Ok(mut file) = File::open(&pid_file) {
@@ -1019,12 +1570,11 @@ async fn check_pid(postfix: &str) {
 }
 
 #[inline]
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn write_pid(postfix: &str) {
     let path = get_pid_file(postfix);
     if let Ok(mut file) = File::create(&path) {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o0777)).ok();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o0600)).ok();
         file.write_all(&std::process::id().to_string().into_bytes())
             .ok();
     }
@@ -1149,6 +1699,143 @@ pub fn get_permanent_password() -> String {
         v
     } else {
         Config::get_permanent_password()
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl<T> ConnectionTmpl<T>
+where
+    T: AsyncRead + AsyncWrite + std::marker::Unpin + std::os::fd::AsRawFd,
+{
+    fn peer_uid(&self) -> Option<u32> {
+        let fd = self.inner.get_ref().as_raw_fd();
+        #[cfg(target_os = "linux")]
+        {
+            let mut cred: hbb_common::libc::ucred = unsafe { std::mem::zeroed() };
+            let mut len =
+                std::mem::size_of::<hbb_common::libc::ucred>() as hbb_common::libc::socklen_t;
+            let rc = unsafe {
+                hbb_common::libc::getsockopt(
+                    fd,
+                    hbb_common::libc::SOL_SOCKET,
+                    hbb_common::libc::SO_PEERCRED,
+                    &mut cred as *mut _ as *mut hbb_common::libc::c_void,
+                    &mut len,
+                )
+            };
+            if rc == 0 {
+                return Some(cred.uid as u32);
+            }
+            return None;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let mut uid: hbb_common::libc::uid_t = 0;
+            let mut gid: hbb_common::libc::gid_t = 0;
+            if unsafe { hbb_common::libc::getpeereid(fd, &mut uid, &mut gid) } == 0 {
+                Some(uid as u32)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn service_authorization_status(&self) -> (bool, Option<u32>, Option<u32>) {
+        let peer_uid = self.peer_uid();
+        let active_uid = active_uid_cached();
+        let authorized = peer_uid.is_some_and(|uid| is_allowed_service_peer_uid(uid, active_uid));
+        (authorized, peer_uid, active_uid)
+    }
+}
+
+#[cfg(windows)]
+impl ConnectionTmpl<Conn> {
+    fn peer_pid(&self) -> Option<u32> {
+        let pipe_handle = self.inner.get_ref().as_raw_handle();
+        if pipe_handle.is_null() {
+            return None;
+        }
+        let mut pid = 0u32;
+        let ok = unsafe { GetNamedPipeClientProcessId(HANDLE(pipe_handle), &mut pid as *mut u32) }
+            .is_ok();
+        if ok && pid != 0 {
+            Some(pid)
+        } else {
+            None
+        }
+    }
+
+    fn server_authorization_status(
+        &self,
+    ) -> (bool, Option<u32>, Option<u32>, Option<u32>, Option<bool>) {
+        let peer_pid = self.peer_pid();
+        let server_session_id = crate::platform::windows::get_current_process_session_id();
+        let peer_session_id =
+            peer_pid.and_then(crate::platform::windows::get_session_id_of_process);
+        let peer_is_system_result =
+            peer_pid.map(crate::platform::windows::is_process_running_as_system);
+        let peer_is_system = peer_is_system_result
+            .as_ref()
+            .and_then(|r| r.as_ref().ok().copied());
+        if server_session_id.is_none() && !peer_is_system.unwrap_or(false) {
+            // When the server session id cannot be determined, the session-id allow-path is
+            // disabled and only SYSTEM peers can be authorized.
+            log::debug!(
+                "IPC authorization: server session id unavailable; rejecting non-SYSTEM peer, peer_pid={:?}, peer_session_id={:?}",
+                peer_pid,
+                peer_session_id
+            );
+        }
+        let authorized = is_allowed_windows_server_peer(
+            peer_is_system.unwrap_or(false),
+            peer_session_id,
+            server_session_id,
+        );
+        if !authorized {
+            if let (Some(pid), Some(Err(err))) = (peer_pid, peer_is_system_result.as_ref()) {
+                log::debug!(
+                    "Failed to determine whether peer process is SYSTEM, pid={}, err={}",
+                    pid,
+                    err
+                );
+            }
+        }
+        (
+            authorized,
+            peer_pid,
+            peer_session_id,
+            server_session_id,
+            peer_is_system,
+        )
+    }
+
+    pub(crate) fn service_authorization_status_for_session(
+        &self,
+        expected_active_session_id: Option<u32>,
+    ) -> (bool, Option<u32>, Option<u32>, Option<bool>) {
+        let peer_pid = self.peer_pid();
+        let peer_session_id =
+            peer_pid.and_then(crate::platform::windows::get_session_id_of_process);
+        let peer_is_system_result =
+            peer_pid.map(crate::platform::windows::is_process_running_as_system);
+        let peer_is_system = peer_is_system_result
+            .as_ref()
+            .and_then(|r| r.as_ref().ok().copied());
+        let authorized = is_allowed_windows_service_peer(
+            peer_is_system.unwrap_or(false),
+            peer_session_id,
+            expected_active_session_id,
+        );
+        if !authorized {
+            if let (Some(pid), Some(Err(err))) = (peer_pid, peer_is_system_result.as_ref()) {
+                log::debug!(
+                    "Failed to determine whether peer process is SYSTEM, pid={}, err={}",
+                    pid,
+                    err
+                );
+            }
+        }
+        (authorized, peer_pid, peer_session_id, peer_is_system)
     }
 }
 
@@ -1416,9 +2103,10 @@ pub fn close_all_instances() -> ResultType<bool> {
     }
 }
 
+#[cfg(windows)]
 #[tokio::main(flavor = "current_thread")]
 pub async fn connect_to_user_session(usid: Option<u32>) -> ResultType<()> {
-    let mut stream = crate::ipc::connect(1000, crate::POSTFIX_SERVICE).await?;
+    let mut stream = crate::ipc::connect_service(1000).await?;
     timeout(1000, stream.send(&crate::ipc::Data::UserSid(usid))).await??;
     Ok(())
 }
@@ -1544,13 +2232,76 @@ pub async fn update_controlling_session_count(count: usize) -> ResultType<()> {
 #[cfg(target_os = "linux")]
 #[tokio::main(flavor = "current_thread")]
 pub async fn get_terminal_session_count() -> ResultType<usize> {
-    let ms_timeout = 1_000;
-    let mut c = connect(ms_timeout, "").await?;
-    c.send(&Data::TerminalSessionCount(0)).await?;
-    if let Some(Data::TerminalSessionCount(c)) = c.next_timeout(ms_timeout).await? {
-        return Ok(c);
+    let timeout_ms = 1_000;
+    let effective_uid = unsafe { hbb_common::libc::geteuid() as u32 };
+    let candidate_uids = terminal_count_candidate_uids(effective_uid);
+    let mut last_err: Option<anyhow::Error> = None;
+    for candidate_uid in candidate_uids {
+        let socket_path = Config::ipc_path_for_uid(candidate_uid, "");
+        let connect_result = timeout(timeout_ms, Endpoint::connect(&socket_path))
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "Timeout connecting to terminal ipc at {}: {}",
+                    socket_path,
+                    err
+                )
+            });
+        let connection = match connect_result {
+            Ok(Ok(connection)) => connection,
+            Ok(Err(err)) => {
+                last_err = Some(anyhow::anyhow!(
+                    "Failed to connect to terminal ipc at {}: {}",
+                    socket_path,
+                    err
+                ));
+                continue;
+            }
+            Err(err) => {
+                last_err = Some(err);
+                continue;
+            }
+        };
+        let mut ipc_conn = ConnectionTmpl::new(connection);
+        if let Err(err) = ipc_conn.send(&Data::TerminalSessionCount(0)).await {
+            last_err = Some(anyhow::anyhow!(
+                "Failed to request terminal session count via ipc at {}: {}",
+                socket_path,
+                err
+            ));
+            continue;
+        }
+        match ipc_conn.next_timeout(timeout_ms).await {
+            Ok(Some(Data::TerminalSessionCount(session_count))) => {
+                return Ok(session_count);
+            }
+            Ok(None) => {
+                last_err = Some(anyhow::anyhow!(
+                    "Invalid response when requesting terminal session count via ipc at {}",
+                    socket_path
+                ));
+            }
+            Ok(other) => {
+                last_err = Some(anyhow::anyhow!(
+                    "Unexpected response when requesting terminal session count via ipc at {}: {:?}",
+                    socket_path,
+                    other.map(|v| std::mem::discriminant(&v))
+                ));
+            }
+            Err(err) => {
+                last_err = Some(anyhow::anyhow!(
+                    "Failed to read terminal session count via ipc at {}: {}",
+                    socket_path,
+                    err
+                ));
+            }
+        }
     }
-    Ok(0)
+    if let Some(err) = last_err {
+        Err(err.into())
+    } else {
+        Ok(0)
+    }
 }
 
 async fn handle_wayland_screencast_restore_token(
@@ -1581,9 +2332,127 @@ pub async fn set_install_option(k: String, v: String) -> ResultType<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+
     #[test]
     fn verify_ffi_enum_data_size() {
         println!("{}", std::mem::size_of::<Data>());
         assert!(std::mem::size_of::<Data>() <= 120);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn test_service_peer_uid_policy() {
+        assert!(is_allowed_service_peer_uid(0, None));
+        assert!(is_allowed_service_peer_uid(501, Some(501)));
+        assert!(!is_allowed_service_peer_uid(502, Some(501)));
+        assert!(!is_allowed_service_peer_uid(501, None));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_windows_server_peer_policy() {
+        assert!(is_allowed_windows_server_peer(true, None, None));
+        assert!(is_allowed_windows_server_peer(false, Some(1), Some(1)));
+        assert!(!is_allowed_windows_server_peer(false, Some(1), Some(2)));
+        assert!(!is_allowed_windows_server_peer(false, None, Some(1)));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_windows_service_peer_policy() {
+        assert!(is_allowed_windows_service_peer(true, None, None));
+        assert!(is_allowed_windows_service_peer(false, Some(1), Some(1)));
+        assert!(!is_allowed_windows_service_peer(false, Some(1), Some(2)));
+        assert!(!is_allowed_windows_service_peer(false, None, Some(1)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_secure_ipc_parent_dir_rejects_symlink_parent() {
+        use std::os::unix::fs::symlink;
+
+        let unique = format!(
+            "rustdesk-ipc-secure-dir-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let base = std::env::temp_dir().join(unique);
+        let real_dir = base.join("real");
+        let link_dir = base.join("link");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        symlink(&real_dir, &link_dir).unwrap();
+        let ipc_path = link_dir.join("ipc_service");
+        let res = ensure_secure_ipc_parent_dir(ipc_path.to_string_lossy().as_ref(), "_service");
+        assert!(res.is_err());
+        std::fs::remove_file(&link_dir).ok();
+        std::fs::remove_dir_all(&real_dir).ok();
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_secure_ipc_parent_dir_creates_parent_with_expected_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let unique = format!(
+            "rustdesk-ipc-secure-dir-create-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let base = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&base).unwrap();
+
+        // Intentionally choose a parent that does not exist to exercise the ENOENT -> mkdir branch.
+        let parent_dir = base.join("parent");
+        assert!(!parent_dir.exists());
+        let ipc_path = parent_dir.join("ipc");
+
+        let res = ensure_secure_ipc_parent_dir(ipc_path.to_string_lossy().as_ref(), "");
+        assert!(res.is_ok());
+
+        let md = std::fs::metadata(&parent_dir).unwrap();
+        assert!(md.is_dir());
+        let mode = md.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o0700);
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_console_owner_uid_matches_get_active_userid() {
+        let console_uid = console_owner_uid().expect("/dev/console must have a resolvable uid");
+        let raw_uid = crate::platform::macos::get_active_userid();
+        let parsed_uid: u32 = raw_uid
+            .trim()
+            .parse()
+            .unwrap_or_else(|_| panic!("failed to parse get_active_userid() output: '{raw_uid}'"));
+        assert_eq!(parsed_uid, console_uid);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_ipc_path_differs_by_uid_for_cm() {
+        let effective_uid = unsafe { hbb_common::libc::geteuid() as u32 };
+        let other_uid = effective_uid.saturating_add(1);
+        let postfix = "_cm";
+
+        // Default connect path targets the current effective uid.
+        assert_eq!(
+            Config::ipc_path(postfix),
+            Config::ipc_path_for_uid(effective_uid, postfix)
+        );
+        // A different uid yields a different socket path - this is the root cause of the
+        // cross-user regression when root spawns a user process but still connects as uid 0.
+        assert_ne!(
+            Config::ipc_path(postfix),
+            Config::ipc_path_for_uid(other_uid, postfix)
+        );
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -651,7 +651,13 @@ fn should_start_server(
         && ((*cm0 && last_restart.elapsed().as_secs() > 60)
             || last_restart.elapsed().as_secs() > 3600)
     {
-        let terminal_session_count = crate::ipc::get_terminal_session_count().unwrap_or(0);
+        let terminal_session_count = match crate::ipc::get_terminal_session_count() {
+            Ok(count) => count,
+            Err(err) => {
+                log::debug!("terminal_session_count unavailable; assuming 0: {}", err);
+                0
+            }
+        };
         if terminal_session_count > 0 {
             // There are terminal sessions, so we don't restart the server.
             // We also need to keep `cm0` unchanged, so that we can reach this branch the next time.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -73,9 +73,17 @@ use winapi::{
 };
 use windows::Win32::{
     Foundation::{CloseHandle as WinCloseHandle, HANDLE as WinHANDLE},
+    Security::{
+        GetTokenInformation as WinGetTokenInformation, IsWellKnownSid, TokenUser,
+        WinLocalSystemSid, TOKEN_QUERY as WIN_TOKEN_QUERY, TOKEN_USER,
+    },
     System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
         TH32CS_SNAPPROCESS,
+    },
+    System::Threading::{
+        OpenProcess as WinOpenProcess, OpenProcessToken as WinOpenProcessToken,
+        PROCESS_QUERY_LIMITED_INFORMATION as WIN_PROCESS_QUERY_LIMITED_INFORMATION,
     },
 };
 use windows_service::{
@@ -631,6 +639,46 @@ async fn run_service(_arguments: Vec<OsString>) -> ResultType<()> {
             Ok(res) => match res {
                 Some(Ok(stream)) => {
                     let mut stream = ipc::Connection::new(stream);
+                    // Keep IPC authorization consistent with the session we are currently serving.
+                    // Recompute expected session right before authorization to avoid using a stale
+                    // session_id after awaiting incoming.next().
+                    let expected_active_session_id = {
+                        let share_rdp_enabled = is_share_rdp();
+                        if !share_rdp_enabled {
+                            let current_active_session = unsafe { get_current_session(FALSE) };
+                            if current_active_session == u32::MAX {
+                                None
+                            } else {
+                                Some(current_active_session)
+                            }
+                        } else {
+                            let has_session_id = get_available_sessions(false)
+                                .iter()
+                                .any(|e| e.sid == session_id);
+                            if !has_session_id {
+                                let current_active_session = unsafe { get_current_session(TRUE) };
+                                if current_active_session == u32::MAX {
+                                    None
+                                } else {
+                                    Some(current_active_session)
+                                }
+                            } else {
+                                Some(session_id)
+                            }
+                        }
+                    };
+                    let (authorized, peer_pid, peer_session_id, peer_is_system) =
+                        stream.service_authorization_status_for_session(expected_active_session_id);
+                    if !authorized {
+                        ipc::log_rejected_windows_ipc_connection(
+                            crate::POSTFIX_SERVICE,
+                            peer_pid,
+                            peer_session_id,
+                            expected_active_session_id,
+                            peer_is_system,
+                        );
+                        continue;
+                    }
                     if let Ok(Some(data)) = stream.next_timeout(1000).await {
                         match data {
                             ipc::Data::Close => {
@@ -2401,6 +2449,85 @@ pub fn is_elevated(process_id: Option<DWORD>) -> ResultType<bool> {
         }
 
         Ok(token_elevation.TokenIsElevated != 0)
+    }
+}
+
+/// Similar to `is_root()` / `is_local_system()` but for an arbitrary process.
+///
+/// Returns `true` if the target process is running as LocalSystem (SID: S-1-5-18).
+///
+/// TODO: After a few releases of real-world validation, consider replacing
+/// the legacy `is_local_system()` with this implementation.
+pub fn is_process_running_as_system(process_id: DWORD) -> ResultType<bool> {
+    unsafe {
+        let process = WinOpenProcess(WIN_PROCESS_QUERY_LIMITED_INFORMATION, false, process_id)
+            .map_err(|e| anyhow!("Failed to open process {}: {}", process_id, e))?;
+
+        let mut token = WinHANDLE::default();
+        let result = (|| -> ResultType<bool> {
+            WinOpenProcessToken(process, WIN_TOKEN_QUERY, &mut token)
+                .map_err(|e| anyhow!("Failed to open process {} token: {}", process_id, e))?;
+
+            let mut token_user_size = 0u32;
+            let get_info_result =
+                WinGetTokenInformation(token, TokenUser, None, 0, &mut token_user_size);
+            match get_info_result {
+                Ok(()) => {
+                    if token_user_size == 0 {
+                        bail!(
+                            "Failed to get process {} token user size: unexpected zero buffer size",
+                            process_id
+                        );
+                    }
+                }
+                Err(e) => {
+                    // Allow the expected ERROR_INSUFFICIENT_BUFFER path where token_user_size
+                    // is set to the required size.
+                    let is_insufficient_buffer = e.code()
+                        == windows::core::HRESULT::from_win32(ERROR_INSUFFICIENT_BUFFER as u32);
+                    // Some Windows versions may return ERROR_BAD_LENGTH for size-probe calls while
+                    // still setting the required size.
+                    let is_bad_length =
+                        e.code() == windows::core::HRESULT::from_win32(ERROR_BAD_LENGTH as u32);
+                    if (!is_insufficient_buffer && !is_bad_length) || token_user_size == 0 {
+                        bail!(
+                            "Failed to get process {} token user size: {}",
+                            process_id,
+                            e
+                        );
+                    }
+                }
+            }
+
+            let mut buffer = vec![0u8; token_user_size as usize];
+            WinGetTokenInformation(
+                token,
+                TokenUser,
+                Some(buffer.as_mut_ptr() as *mut core::ffi::c_void),
+                token_user_size,
+                &mut token_user_size,
+            )
+            .map_err(|e| anyhow!("Failed to get process {} token user: {}", process_id, e))?;
+
+            let min_size = std::mem::size_of::<TOKEN_USER>();
+            if buffer.len() < min_size {
+                bail!(
+                    "Failed to parse process {} token user: buffer too small (got {}, need >= {})",
+                    process_id,
+                    buffer.len(),
+                    min_size
+                );
+            }
+            let token_user: TOKEN_USER =
+                std::ptr::read_unaligned(buffer.as_ptr() as *const TOKEN_USER);
+            Ok(IsWellKnownSid(token_user.User.Sid, WinLocalSystemSid).as_bool())
+        })();
+
+        if !token.is_invalid() {
+            let _ = WinCloseHandle(token);
+        }
+        let _ = WinCloseHandle(process);
+        result
     }
 }
 
@@ -4263,6 +4390,90 @@ pub(super) fn get_pids_with_first_arg_by_wmic<S1: AsRef<str>, S2: AsRef<str>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct HandleGuard(WinHANDLE);
+
+    impl HandleGuard {
+        #[inline]
+        fn new(handle: WinHANDLE) -> Self {
+            Self(handle)
+        }
+
+        #[inline]
+        fn get(&self) -> WinHANDLE {
+            self.0
+        }
+    }
+
+    impl Drop for HandleGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.0.is_invalid() {
+                    let _ = WinCloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_process_running_as_system_invalid_pid_errors() {
+        assert!(is_process_running_as_system(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn test_is_process_running_as_system_matches_current_process_token_user() {
+        let pid = unsafe { GetCurrentProcessId() };
+        let actual = is_process_running_as_system(pid).unwrap();
+
+        let expected = unsafe {
+            // Keep this test consistent: use only the `windows` crate APIs/types.
+            let process = HandleGuard::new(
+                WinOpenProcess(WIN_PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+                    .expect("WinOpenProcess should succeed for current process"),
+            );
+            let mut token = WinHANDLE::default();
+            WinOpenProcessToken(process.get(), WIN_TOKEN_QUERY, &mut token)
+                .expect("WinOpenProcessToken should succeed for current process");
+            let token = HandleGuard::new(token);
+
+            let mut token_user_size = 0u32;
+            let _ = WinGetTokenInformation(token.get(), TokenUser, None, 0, &mut token_user_size);
+            assert_ne!(token_user_size, 0, "TokenUser size should be non-zero");
+
+            let mut buffer = vec![0u8; token_user_size as usize];
+            WinGetTokenInformation(
+                token.get(),
+                TokenUser,
+                Some(buffer.as_mut_ptr() as *mut core::ffi::c_void),
+                token_user_size,
+                &mut token_user_size,
+            )
+            .expect("WinGetTokenInformation(TokenUser) should succeed for current process");
+
+            let min_size = std::mem::size_of::<TOKEN_USER>();
+            assert!(
+                buffer.len() >= min_size,
+                "TokenUser buffer too small (got {}, need >= {})",
+                buffer.len(),
+                min_size
+            );
+            let token_user: TOKEN_USER =
+                std::ptr::read_unaligned(buffer.as_ptr() as *const TOKEN_USER);
+            let expected = IsWellKnownSid(token_user.User.Sid, WinLocalSystemSid).as_bool();
+            expected
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_is_process_running_as_system_matches_is_root_for_current_process() {
+        let pid = unsafe { GetCurrentProcessId() };
+        let actual = is_process_running_as_system(pid).unwrap();
+        let expected = is_root();
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn test_uninstall_cert() {
         println!("uninstall driver certs: {:?}", cert::uninstall_cert());

--- a/src/server.rs
+++ b/src/server.rs
@@ -731,7 +731,7 @@ async fn sync_and_watch_config_dir(sync_done_tx: Option<tokio::sync::oneshot::Se
     use hbb_common::sleep;
     for i in 1..=tries {
         sleep(i as f32 * CONFIG_SYNC_INTERVAL_SECS).await;
-        match crate::ipc::connect(1000, "_service").await {
+        match crate::ipc::connect_service(1000).await {
             Ok(mut conn) => {
                 if !synced {
                     if conn.send(&Data::SyncConfig(None)).await.is_ok() {
@@ -788,7 +788,7 @@ async fn sync_and_watch_config_dir(sync_done_tx: Option<tokio::sync::oneshot::Se
                         match conn.send(&Data::SyncConfig(Some(cfg.clone().into()))).await {
                             Err(e) => {
                                 log::error!("sync config to root failed: {}", e);
-                                match crate::ipc::connect(1000, "_service").await {
+                                match crate::ipc::connect_service(1000).await {
                                     Ok(mut _conn) => {
                                         conn = _conn;
                                         log::info!("reconnected to ipc_service");

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4809,6 +4809,14 @@ async fn start_ipc(
             user = Some((uid, username));
             args = vec!["--cm-no-ui"];
         }
+        #[cfg(target_os = "linux")]
+        let cm_uid: Option<u32> = match &user {
+            Some((uid, _)) => Some(
+                uid.parse::<u32>()
+                    .map_err(|_| anyhow!("Invalid uid {}", uid))?,
+            ),
+            None => None,
+        };
         let run_done;
         if crate::platform::is_root() {
             let mut res = Ok(None);
@@ -4849,6 +4857,16 @@ async fn start_ipc(
         }
         for _ in 0..20 {
             sleep(0.3).await;
+            #[cfg(target_os = "linux")]
+            {
+                if let Some(uid) = cm_uid {
+                    if let Ok(s) = crate::ipc::connect_for_uid(1000, uid, "_cm").await {
+                        stream = Some(s);
+                        break;
+                    }
+                    continue;
+                }
+            }
             if let Ok(s) = crate::ipc::connect(1000, "_cm").await {
                 stream = Some(s);
                 break;

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -185,10 +185,14 @@ pub mod client {
 pub mod service {
     use super::*;
     use hbb_common::lazy_static;
+    #[cfg(target_os = "linux")]
+    use parity_tokio_ipc::Connection as RawIpcConnection;
     use scrap::wayland::{
         pipewire::RDP_SESSION_INFO, remote_desktop_portal::OrgFreedesktopPortalRemoteDesktop,
     };
     use std::{collections::HashMap, sync::Mutex};
+    #[cfg(target_os = "linux")]
+    use std::os::fd::AsRawFd;
 
     lazy_static::lazy_static! {
     static ref KEY_MAP: HashMap<enigo::Key, evdev::Key> = HashMap::from(
@@ -909,6 +913,54 @@ pub mod service {
         });
     }
 
+    #[cfg(target_os = "linux")]
+    #[inline]
+    fn active_uid_for_uinput() -> Option<u32> {
+        crate::platform::linux::get_active_userid().trim().parse::<u32>().ok()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn peer_uid_for_uinput(stream: &RawIpcConnection) -> Option<u32> {
+        let fd = stream.as_raw_fd();
+        let mut cred: hbb_common::libc::ucred = unsafe { std::mem::zeroed() };
+        let mut len =
+            std::mem::size_of::<hbb_common::libc::ucred>() as hbb_common::libc::socklen_t;
+        let rc = unsafe {
+            hbb_common::libc::getsockopt(
+                fd,
+                hbb_common::libc::SOL_SOCKET,
+                hbb_common::libc::SO_PEERCRED,
+                &mut cred as *mut _ as *mut hbb_common::libc::c_void,
+                &mut len,
+            )
+        };
+        if rc == 0 {
+            Some(cred.uid as u32)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[inline]
+    fn is_allowed_uinput_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
+        peer_uid == 0 || active_uid.is_some_and(|uid| uid == peer_uid)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn authorize_uinput_peer(postfix: &str, stream: &RawIpcConnection) -> bool {
+        if !hbb_common::config::is_service_ipc_postfix(postfix) {
+            return true;
+        }
+        let peer_uid = peer_uid_for_uinput(stream);
+        let active_uid = active_uid_for_uinput();
+        let authorized = peer_uid.is_some_and(|uid| is_allowed_uinput_peer_uid(uid, active_uid));
+        if !authorized {
+            crate::ipc::log_rejected_uinput_connection(postfix, peer_uid, active_uid);
+        }
+        authorized
+    }
+
     /// Start uinput service.
     async fn start_service<F: FnOnce(ipc::Connection) + Copy>(postfix: &str, handler: F) {
         match new_listener(postfix).await {
@@ -916,6 +968,10 @@ pub mod service {
                 while let Some(result) = incoming.next().await {
                     match result {
                         Ok(stream) => {
+                            #[cfg(target_os = "linux")]
+                            if !authorize_uinput_peer(postfix, &stream) {
+                                continue;
+                            }
                             log::debug!("Got new connection of uinput ipc {}", postfix);
                             handler(Connection::new(stream));
                         }

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -190,9 +190,9 @@ pub mod service {
     use scrap::wayland::{
         pipewire::RDP_SESSION_INFO, remote_desktop_portal::OrgFreedesktopPortalRemoteDesktop,
     };
-    use std::{collections::HashMap, sync::Mutex};
     #[cfg(target_os = "linux")]
-    use std::os::fd::AsRawFd;
+    use std::os::unix::io::AsRawFd;
+    use std::{collections::HashMap, sync::Mutex};
 
     lazy_static::lazy_static! {
     static ref KEY_MAP: HashMap<enigo::Key, evdev::Key> = HashMap::from(
@@ -606,7 +606,10 @@ pub mod service {
             }
             DataKeyboard::KeyDown(enigo::Key::Raw(code)) => {
                 if *code < 8 {
-                    log::error!("Invalid Raw keycode {} (must be >= 8 due to XKB offset), skipping", code);
+                    log::error!(
+                        "Invalid Raw keycode {} (must be >= 8 due to XKB offset), skipping",
+                        code
+                    );
                 } else {
                     let down_event = InputEvent::new(EventType::KEY, *code - 8, 1);
                     allow_err!(keyboard.emit(&[down_event]));
@@ -614,7 +617,10 @@ pub mod service {
             }
             DataKeyboard::KeyUp(enigo::Key::Raw(code)) => {
                 if *code < 8 {
-                    log::error!("Invalid Raw keycode {} (must be >= 8 due to XKB offset), skipping", code);
+                    log::error!(
+                        "Invalid Raw keycode {} (must be >= 8 due to XKB offset), skipping",
+                        code
+                    );
                 } else {
                     let up_event = InputEvent::new(EventType::KEY, *code - 8, 0);
                     allow_err!(keyboard.emit(&[up_event]));
@@ -914,47 +920,14 @@ pub mod service {
     }
 
     #[cfg(target_os = "linux")]
-    #[inline]
-    fn active_uid_for_uinput() -> Option<u32> {
-        crate::platform::linux::get_active_userid().trim().parse::<u32>().ok()
-    }
-
-    #[cfg(target_os = "linux")]
-    fn peer_uid_for_uinput(stream: &RawIpcConnection) -> Option<u32> {
-        let fd = stream.as_raw_fd();
-        let mut cred: hbb_common::libc::ucred = unsafe { std::mem::zeroed() };
-        let mut len =
-            std::mem::size_of::<hbb_common::libc::ucred>() as hbb_common::libc::socklen_t;
-        let rc = unsafe {
-            hbb_common::libc::getsockopt(
-                fd,
-                hbb_common::libc::SOL_SOCKET,
-                hbb_common::libc::SO_PEERCRED,
-                &mut cred as *mut _ as *mut hbb_common::libc::c_void,
-                &mut len,
-            )
-        };
-        if rc == 0 {
-            Some(cred.uid as u32)
-        } else {
-            None
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    #[inline]
-    fn is_allowed_uinput_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
-        peer_uid == 0 || active_uid.is_some_and(|uid| uid == peer_uid)
-    }
-
-    #[cfg(target_os = "linux")]
     fn authorize_uinput_peer(postfix: &str, stream: &RawIpcConnection) -> bool {
         if !hbb_common::config::is_service_ipc_postfix(postfix) {
             return true;
         }
-        let peer_uid = peer_uid_for_uinput(stream);
-        let active_uid = active_uid_for_uinput();
-        let authorized = peer_uid.is_some_and(|uid| is_allowed_uinput_peer_uid(uid, active_uid));
+        let peer_uid = ipc::peer_uid_from_fd(stream.as_raw_fd());
+        let active_uid = ipc::active_uid_cached();
+        let authorized =
+            peer_uid.is_some_and(|uid| ipc::is_allowed_service_peer_uid(uid, active_uid));
         if !authorized {
             crate::ipc::log_rejected_uinput_connection(postfix, peer_uid, active_uid);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated protected service connection channel with stronger per-session authorization
  * Improved multi-user support on Linux/macOS with per-user IPC paths and session-aware handling
  * Enhanced reconnection flow to use the protected service channel

* **Bug Fixes**
  * Hardened platform authorization that rejects unauthorized IPC peers and reduces noisy logs
  * Improved Windows process/session validation for more reliable access decisions
  * Safer socket/directory protections and guarded startup checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->