### PR TITLE
Store permanent password as hashed verifier

### DIFF
--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -908,12 +908,11 @@ class _DesktopHomePageState extends State<DesktopHomePage>
 }
 
 void setPasswordDialog({VoidCallback? notEmptyCallback}) async {
-  final pw = await bind.mainGetPermanentPassword();
-  final p0 = TextEditingController(text: pw);
-  final p1 = TextEditingController(text: pw);
+  final p0 = TextEditingController(text: "");
+  final p1 = TextEditingController(text: "");
   var errMsg0 = "";
   var errMsg1 = "";
-  final RxString rxPass = pw.trim().obs;
+  final RxString rxPass = "".obs;
   final rules = [
     DigitValidationRule(),
     UppercaseValidationRule(),

--- a/flutter/lib/mobile/widgets/dialog.dart
+++ b/flutter/lib/mobile/widgets/dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common/widgets/custom_password.dart';
 import 'package:flutter_hbb/common/widgets/setting_widgets.dart';
 import 'package:flutter_hbb/common/widgets/toolbar.dart';
 import 'package:get/get.dart';
@@ -17,12 +18,30 @@ void _showError() {
 }
 
 void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
-  final pw = await bind.mainGetPermanentPassword();
-  final p0 = TextEditingController(text: pw);
-  final p1 = TextEditingController(text: pw);
-  var validateLength = false;
-  var validateSame = false;
+  final p0 = TextEditingController(text: "");
+  final p1 = TextEditingController(text: "");
+  final formKey = GlobalKey<FormState>();
+  final rules = [
+    DigitValidationRule(),
+    UppercaseValidationRule(),
+    LowercaseValidationRule(),
+    MinCharactersValidationRule(8),
+  ];
   dialogManager.show((setState, close, context) {
+    bool canSubmit() {
+      final a = p0.text;
+      final b = p1.text;
+      if (a.isEmpty && b.isEmpty) {
+        // Allow clearing the permanent password.
+        return true;
+      }
+      if (a != b) {
+        return false;
+      }
+      final Iterable violations = rules.where((r) => !r.validate(a));
+      return violations.isEmpty;
+    }
+
     submit() async {
       close();
       dialogManager.showLoading(translate("Waiting"));
@@ -44,6 +63,7 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
         ],
       ),
       content: Form(
+          key: formKey,
           autovalidateMode: AutovalidateMode.onUserInteraction,
           child: Column(mainAxisSize: MainAxisSize.min, children: [
             TextFormField(
@@ -54,17 +74,21 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
                 labelText: translate('Password'),
               ),
               controller: p0,
+              onChanged: (_) {
+                setState(() {});
+                // Revalidate confirmation field when primary password changes.
+                formKey.currentState?.validate();
+              },
               validator: (v) {
                 if (v == null) return null;
-                final val = v.trim().length > 5;
-                if (validateLength != val) {
-                  // use delay to make setState success
-                  Future.delayed(Duration(microseconds: 1),
-                      () => setState(() => validateLength = val));
+                if (v.isEmpty) {
+                  return null;
                 }
-                return val
-                    ? null
-                    : translate('Too short, at least 6 characters.');
+                final Iterable violations = rules.where((r) => !r.validate(v));
+                if (violations.isNotEmpty) {
+                  return '${translate('Prompt')}: ${violations.map((r) => r.name).join(', ')}';
+                }
+                return null;
               },
             ).workaroundFreezeLinuxMint(),
             TextFormField(
@@ -74,21 +98,21 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
                 labelText: translate('Confirmation'),
               ),
               controller: p1,
+              onChanged: (_) {
+                setState(() {});
+                formKey.currentState?.validate();
+              },
               validator: (v) {
                 if (v == null) return null;
-                final val = p0.text == v;
-                if (validateSame != val) {
-                  Future.delayed(Duration(microseconds: 1),
-                      () => setState(() => validateSame = val));
-                }
-                return val
+                final ok = p0.text == v;
+                return ok
                     ? null
                     : translate('The confirmation is not identical.');
               },
             ).workaroundFreezeLinuxMint(),
           ])),
       onCancel: close,
-      onSubmit: (validateLength && validateSame) ? submit : null,
+      onSubmit: canSubmit() ? submit : null,
       actions: [
         dialogButton(
           'Cancel',
@@ -99,7 +123,7 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
         dialogButton(
           'OK',
           icon: Icon(Icons.done_rounded),
-          onPressed: (validateLength && validateSame) ? submit : null,
+          onPressed: canSubmit() ? submit : null,
         ),
       ],
     );

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -472,14 +472,22 @@ class ServerModel with ChangeNotifier {
   }
 
   Future<bool> setPermanentPassword(String newPW) async {
-    await bind.mainSetPermanentPassword(password: newPW);
-    await Future.delayed(Duration(milliseconds: 500));
-    final pw = await bind.mainGetPermanentPassword();
-    if (newPW == pw) {
-      return true;
-    } else {
+    final ok = await bind.mainSetPermanentPasswordWithResult(password: newPW);
+    if (!ok) {
       return false;
     }
+    // Avoid reading back any secret. Wait (bounded) until the expected state is observed.
+    final expected = newPW.isNotEmpty;
+    const maxTries = 10;
+    const pollDelay = Duration(milliseconds: 100);
+    for (var i = 0; i < maxTries; i++) {
+      final hasPw = await bind.mainIsPermanentPasswordSet();
+      if (hasPw == expected) {
+        return true;
+      }
+      await Future.delayed(pollDelay);
+    }
+    return false;
   }
 
   fetchID() async {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1697,6 +1697,25 @@ pub fn main_get_permanent_password() -> String {
     ui_interface::permanent_password()
 }
 
+pub fn main_is_permanent_password_set() -> bool {
+    ui_interface::is_permanent_password_set()
+}
+
+pub fn main_set_permanent_password_with_result(password: String) -> bool {
+    if config::Config::is_disable_change_permanent_password() {
+        return false;
+    }
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    {
+        config::Config::set_permanent_password(&password);
+        return true;
+    }
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {
+        crate::ipc::set_permanent_password(password).is_ok()
+    }
+}
+
 pub fn main_get_fingerprint() -> String {
     get_fingerprint()
 }
@@ -2073,7 +2092,11 @@ pub fn main_update_temporary_password() {
 }
 
 pub fn main_set_permanent_password(password: String) {
-    set_permanent_password(password);
+    // Keep legacy signature, but route through the unified setter contract.
+    // This avoids duplicating policy enforcement and backend write paths.
+    if !main_set_permanent_password_with_result(password) {
+        log::warn!("Failed to set permanent password (may be disabled by policy)");
+    }
 }
 
 pub fn main_check_super_user_permission() -> bool {
@@ -2423,16 +2446,23 @@ pub fn is_disable_installation() -> SyncReturn<bool> {
 }
 
 pub fn is_preset_password() -> bool {
-    config::HARD_SETTINGS
+    let hard = config::HARD_SETTINGS
         .read()
         .unwrap()
         .get("password")
-        .map_or(false, |p| {
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            return p == &crate::ipc::get_permanent_password();
-            #[cfg(any(target_os = "android", target_os = "ios"))]
-            return p == &config::Config::get_permanent_password();
-        })
+        .cloned()
+        .unwrap_or_default();
+    if hard.is_empty() {
+        return false;
+    }
+
+    // On desktop, service owns the authoritative config; query it via IPC and return only a boolean.
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    return crate::ipc::is_permanent_password_preset();
+
+    // On mobile, we have no service IPC; verify against local storage.
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    return config::Config::verify_permanent_password(&hard);
 }
 
 // Don't call this function for desktop version.

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -633,7 +633,30 @@ async fn handle(data: Data, stream: &mut Connection) {
                 } else if name == "temporary-password" {
                     value = Some(password::temporary_password());
                 } else if name == "permanent-password" {
-                    value = Some(Config::get_permanent_password());
+                    value = Some(if Config::has_permanent_password() {
+                        "<set>".to_owned()
+                    } else {
+                        String::new()
+                    });
+                } else if name == "permanent-password-set" {
+                    value = Some(if Config::has_permanent_password() {
+                        "Y".to_owned()
+                    } else {
+                        "N".to_owned()
+                    });
+                } else if name == "permanent-password-is-preset" {
+                    let hard = config::HARD_SETTINGS
+                        .read()
+                        .unwrap()
+                        .get("password")
+                        .cloned()
+                        .unwrap_or_default();
+                    let is_preset = !hard.is_empty() && Config::verify_permanent_password(&hard);
+                    value = Some(if is_preset {
+                        "Y".to_owned()
+                    } else {
+                        "N".to_owned()
+                    });
                 } else if name == "salt" {
                     value = Some(Config::get_salt());
                 } else if name == "rendezvous_server" {
@@ -669,13 +692,25 @@ async fn handle(data: Data, stream: &mut Connection) {
                 allow_err!(stream.send(&Data::Config((name, value))).await);
             }
             Some(value) => {
+                let mut updated = true;
                 if name == "id" {
                     Config::set_key_confirmed(false);
                     Config::set_id(&value);
                 } else if name == "temporary-password" {
                     password::update_temporary_password();
                 } else if name == "permanent-password" {
-                    Config::set_permanent_password(&value);
+                    // Guard against older clients that may round-trip a UI sentinel value
+                    // back into the service, which would overwrite the real password.
+                    // Do not trim here: treat passwords as exact strings.
+                    // We only reject the exact sentinel literal to prevent old clients from
+                    // overwriting the password with the UI marker.
+                    if value == "<set>" {
+                        log::error!("Refusing to set permanent password to sentinel value");
+                        updated = false;
+                    } else {
+                        // Do not trim before storing to preserve exact password semantics.
+                        Config::set_permanent_password(&value);
+                    }
                 } else if name == "salt" {
                     Config::set_salt(&value);
                 } else if name == "voice-call-input" {
@@ -685,7 +720,9 @@ async fn handle(data: Data, stream: &mut Connection) {
                 } else {
                     return;
                 }
-                log::info!("{} updated", name);
+                if updated {
+                    log::info!("{} updated", name);
+                }
             }
         },
         Data::Options(value) => match value {
@@ -1106,6 +1143,11 @@ pub async fn get_config(name: &str) -> ResultType<Option<String>> {
     get_config_async(name, 1_000).await
 }
 
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_config_short_timeout(name: &str) -> ResultType<Option<String>> {
+    get_config_async(name, 100).await
+}
+
 async fn get_config_async(name: &str, ms_timeout: u64) -> ResultType<Option<String>> {
     let mut c = connect(ms_timeout, "").await?;
     c.send(&Data::Config((name.to_owned(), None))).await?;
@@ -1144,12 +1186,31 @@ pub fn update_temporary_password() -> ResultType<()> {
 }
 
 pub fn get_permanent_password() -> String {
-    if let Ok(Some(v)) = get_config("permanent-password") {
-        Config::set_permanent_password(&v);
-        v
+    if is_permanent_password_set() {
+        "<set>".to_owned()
     } else {
-        Config::get_permanent_password()
+        String::new()
     }
+}
+
+pub fn is_permanent_password_set() -> bool {
+    if let Ok(Some(v)) = get_config_short_timeout("permanent-password-set") {
+        let v = v.trim();
+        return v == "Y" || v.eq_ignore_ascii_case("true") || v == "1";
+    }
+    // Fallback for older services: any non-empty value means "set" in practice.
+    if let Ok(Some(v)) = get_config_short_timeout("permanent-password") {
+        return !v.is_empty();
+    }
+    Config::has_permanent_password()
+}
+
+pub fn is_permanent_password_preset() -> bool {
+    if let Ok(Some(v)) = get_config("permanent-password-is-preset") {
+        let v = v.trim();
+        return v == "Y" || v.eq_ignore_ascii_case("true") || v == "1";
+    }
+    false
 }
 
 pub fn get_fingerprint() -> String {
@@ -1159,7 +1220,9 @@ pub fn get_fingerprint() -> String {
 }
 
 pub fn set_permanent_password(v: String) -> ResultType<()> {
-    Config::set_permanent_password(&v);
+    if Config::is_disable_change_permanent_password() {
+        bail!("Changing permanent password is disabled");
+    }
     set_config("permanent-password", v)
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -27,6 +27,7 @@ use hbb_common::platform::linux::run_cmds;
 #[cfg(target_os = "android")]
 use hbb_common::protobuf::EnumOrUnknown;
 use hbb_common::{
+    config::decode_permanent_password_h1_from_storage,
     config::{self, keys, Config, TrustedDevice},
     fs::{self, can_enable_overwrite_detection, JobType},
     futures::{SinkExt, StreamExt},
@@ -75,6 +76,18 @@ lazy_static::lazy_static! {
     static ref SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
     static ref WAKELOCK_SENDER: Arc::<Mutex<std::sync::mpsc::Sender<(usize, usize)>>> = Arc::new(Mutex::new(start_wakelock_thread()));
     static ref WAKELOCK_KEEP_AWAKE_OPTION: Arc::<Mutex<Option<bool>>> = Default::default();
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    // Avoid data-dependent early exits.
+    let mut x: u8 = 0;
+    for i in 0..a.len() {
+        x |= a[i] ^ b[i];
+    }
+    x == 0
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -1969,23 +1982,47 @@ impl Connection {
         self.tx_input.send(MessageInput::Key((msg, press))).ok();
     }
 
-    fn validate_one_password(&self, password: String) -> bool {
-        if password.len() == 0 {
+    fn verify_h1(&self, h1: &[u8]) -> bool {
+        let mut hasher2 = Sha256::new();
+        hasher2.update(h1);
+        hasher2.update(self.hash.challenge.as_bytes());
+        constant_time_eq(&hasher2.finalize()[..], &self.lr.password[..])
+    }
+
+    fn validate_password_plaintext(&self, password: &str) -> bool {
+        if password.is_empty() {
             return false;
         }
+
         let mut hasher = Sha256::new();
-        hasher.update(password);
-        hasher.update(&self.hash.salt);
-        let mut hasher2 = Sha256::new();
-        hasher2.update(&hasher.finalize()[..]);
-        hasher2.update(&self.hash.challenge);
-        hasher2.finalize()[..] == self.lr.password[..]
+        hasher.update(password.as_bytes());
+        hasher.update(self.hash.salt.as_bytes());
+        let h1_plain = hasher.finalize();
+        self.verify_h1(&h1_plain[..])
+    }
+
+    fn validate_password_storage(&self, storage: &str) -> bool {
+        if storage.is_empty() {
+            return false;
+        }
+
+        // For hashed-verifier storage, verify only via decoded H1. Never treat the storage
+        // string itself as a plaintext password.
+        if storage.starts_with("01") {
+            if let Some(h1) = decode_permanent_password_h1_from_storage(storage) {
+                return self.verify_h1(&h1[..]);
+            }
+            log::error!("Invalid hashed permanent password storage");
+            return false;
+        }
+        // Legacy plaintext storage path.
+        self.validate_password_plaintext(storage)
     }
 
     fn validate_password(&mut self) -> bool {
         if password::temporary_enabled() {
             let password = password::temporary_password();
-            if self.validate_one_password(password.clone()) {
+            if self.validate_password_plaintext(&password) {
                 raii::AuthedConnID::update_or_insert_session(
                     self.session_key(),
                     Some(password),
@@ -1995,7 +2032,8 @@ impl Connection {
             }
         }
         if password::permanent_enabled() {
-            if self.validate_one_password(Config::get_permanent_password()) {
+            let stored = Config::get_permanent_password();
+            if self.validate_password_storage(&stored) {
                 return true;
             }
         }
@@ -2016,7 +2054,7 @@ impl Connection {
         if let Some(session) = session {
             if !self.lr.password.is_empty()
                 && (tfa && session.tfa
-                    || !tfa && self.validate_one_password(session.random_password.clone()))
+                    || !tfa && self.validate_password_plaintext(&session.random_password))
             {
                 log::info!("is recent session");
                 return true;

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1128,11 +1128,9 @@ class PasswordArea: Reactor.Component {
 
     event click $(li#set-password) {
         var me = this;
-        var password = handler.permanent_password();
-        var value_field = password.length == 0 ? "" : "value=" + password;
         msgbox("custom-password", translate("Set Password"), "<div .form .set-password> \
-            <div><span>" + translate('Password') + ":</span><input|password(password) .outline-focus " + value_field + " /></div> \
-            <div><span>" + translate('Confirmation') + ":</span><input|password(confirmation) " + value_field + " /></div> \
+            <div><span>" + translate('Password') + ":</span><input|password(password) .outline-focus /></div> \
+            <div><span>" + translate('Confirmation') + ":</span><input|password(confirmation) /></div> \
         </div> \
         ", "", function(res=null) {
             if (!res) return;

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -610,18 +610,35 @@ pub fn update_temporary_password() {
 
 #[inline]
 pub fn permanent_password() -> String {
+    // Returns a sentinel ("<set>"/empty), not the plaintext password.
     #[cfg(any(target_os = "android", target_os = "ios"))]
-    return Config::get_permanent_password();
+    return if Config::has_permanent_password() {
+        "<set>".to_owned()
+    } else {
+        String::new()
+    };
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     return ipc::get_permanent_password();
 }
 
 #[inline]
 pub fn set_permanent_password(password: String) {
+    if Config::is_disable_change_permanent_password() {
+        log::warn!("Changing permanent password is disabled");
+        return;
+    }
     #[cfg(any(target_os = "android", target_os = "ios"))]
     Config::set_permanent_password(&password);
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     allow_err!(ipc::set_permanent_password(password));
+}
+
+#[inline]
+pub fn is_permanent_password_set() -> bool {
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    return Config::has_permanent_password();
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    return ipc::is_permanent_password_set();
 }
 
 #[inline]


### PR DESCRIPTION
This change addresses a reported security issue where a permanent ("master") password could be recovered from local configuration due to reversible storage combined with service/user configuration synchronization. The permanent password is now stored as a non-reversible verifier, and UI/IPC no longer exposes or pre-fills the secret.

## Problem
- Permanent password was stored in a reversible form on disk.
- The application may sync configuration between service/root and user config locations.
- As a result, an unprivileged local attacker could retrieve the permanent password from synced configuration, making it impractical to deploy in hardened environments.

## Solution (High Level)
- Store permanent password as a hashed verifier instead of reversible ciphertext or plaintext.
- Keep backward compatibility by migrating existing stored values on load.
- Allow syncing the verifier to user-side config for non-installed usage, but never expose plaintext via UI/IPC.
- Freeze `salt` once the hashed storage format is in use to avoid breaking verification.

## Details
- New storage format: `01$<base64(H1)>`
- `H1 = SHA256(password || salt)` (32 bytes)
- During auth verification:
  - If stored value starts with `01$`, decode `H1` and compute `H2 = SHA256(H1 || challenge)`
  - Otherwise, fall back to legacy behavior (`H1 = SHA256(password || salt)`) for compatibility

## Changes
- `libs/hbb_common/src/config.rs`
  - Add `01$...` hashed permanent password storage.
  - Auto-migrate legacy stored passwords to `01$...` on load.
  - Prevent `salt` changes once permanent password is stored as `01$...`.
  - Guard `Config::set(cfg)` so sync paths cannot silently change `salt` (and keep `password`/`salt` consistent).
- `src/server/connection.rs`
  - Accept both hashed storage (`01$...`) and legacy plaintext-like input during password validation.
- `src/ipc.rs`, `src/ui_interface.rs`
  - IPC `get_config("permanent-password")` returns `"<set>"` or empty string (no secret material).
  - Desktop UI queries service-side "is set" state via IPC without persisting plaintext locally.
- `src/ui/index.tis` (Sciter)
  - "Set permanent password" dialog no longer pre-fills existing password.
- Flutter UI
  - Do not pre-fill permanent password fields.
  - Allow submitting empty fields to clear the permanent password.
  - Adjust success detection to work with "is set" semantics rather than secret readback.

## Backward Compatibility
- Existing configs with legacy permanent password storage are migrated to the new `01$...` format on first load (when possible).
- Service-side validation remains compatible with legacy inputs.

## Tests

  - [ ] Set permanent password, restart, verify remote auth works.
  - [ ] Confirm config does not contain plaintext or reversibly-encrypted permanent password.
  - [ ] Confirm UI does not display or pre-fill permanent password.
  - [ ] Confirm that clearing the permanent password works.

## Notes / Risk
- `salt` becomes a long-lived parameter once hashed storage is active. Sync paths are explicitly prevented from changing it to avoid breaking permanent password verification.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password inputs no longer prefill with the existing permanent password and can be cleared when editing.
  * Verification now supports stored hashed passwords and waits for confirmed persistence after setting.
  * Attempts to change the permanent password are blocked when password changes are disabled.

* **UI Changes**
  * Password status displays "<set>" when configured instead of exposing the actual value.
  * OK/submit gating updated; form-based validation enforces strength rules and matching confirmation while allowing clear-to-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->