### PR TITLE
fix(keyboard): wayland clipboard input prompt

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -15,6 +15,37 @@ import 'package:flutter_hbb/utils/multi_window_manager.dart';
 import 'package:get/get.dart';
 
 bool isEditOsPassword = false;
+const String kPeerOptionAllowWaylandKeyboard = 'allow-wayland-keyboard';
+const String kWaylandKeyboardIssueUrl =
+    'https://github.com/rustdesk/rustdesk/issues/14586';
+final Set<String> _waylandKeyboardPromptSuppressedConnectionIds = <String>{};
+
+bool isWaylandKeyboardPromptSuppressedForConnection(String connectionId) {
+  return _waylandKeyboardPromptSuppressedConnectionIds.contains(connectionId);
+}
+
+void setWaylandKeyboardPromptSuppressedForConnection(
+    String connectionId, bool suppressed) {
+  if (suppressed) {
+    _waylandKeyboardPromptSuppressedConnectionIds.add(connectionId);
+  } else {
+    _waylandKeyboardPromptSuppressedConnectionIds.remove(connectionId);
+  }
+}
+
+void clearWaylandKeyboardPromptSuppressedForConnection(String connectionId) {
+  _waylandKeyboardPromptSuppressedConnectionIds.remove(connectionId);
+}
+
+bool shouldShowWaylandKeyboardPrompt({
+  required String connectionId,
+  required bool isWaylandPeer,
+  required bool allowWaylandKeyboardRemembered,
+}) {
+  return isWaylandPeer &&
+      !allowWaylandKeyboardRemembered &&
+      !isWaylandKeyboardPromptSuppressedForConnection(connectionId);
+}
 
 class TTextMenu {
   final Widget child;
@@ -87,12 +118,135 @@ handleOsPasswordAction(
   }
 }
 
+void showWaylandKeyboardInputWarningDialog(
+    {required String id,
+    required String connectionId,
+    required FFI ffi,
+    required Future<void> Function() onEnable}) {
+  bool remember = false;
+  bool dontAskAgainForConnection = false;
+  bool consentInProgress = false;
+  bool dialogClosed = false;
+
+  final dialogFuture = ffi.dialogManager.show((setState, close, context) {
+    void safeSetState(VoidCallback fn) {
+      if (dialogClosed) {
+        return;
+      }
+      try {
+        setState(fn);
+      } catch (e, st) {
+        debugPrint('Ignore setState after dialog disposal: $e');
+        debugPrintStack(stackTrace: st);
+      }
+    }
+
+    void closeDialog() {
+      if (dialogClosed) {
+        return;
+      }
+      dialogClosed = true;
+      close();
+    }
+
+    Future<void> enableAndContinue() async {
+      if (consentInProgress || dialogClosed) {
+        return;
+      }
+      consentInProgress = true;
+      safeSetState(() {});
+      try {
+        if (remember) {
+          await bind.mainSetPeerOption(
+              id: id,
+              key: kPeerOptionAllowWaylandKeyboard,
+              value: bool2option(kPeerOptionAllowWaylandKeyboard, true));
+        }
+        if (dontAskAgainForConnection) {
+          setWaylandKeyboardPromptSuppressedForConnection(connectionId, true);
+        }
+        ffi.inputModel.keyboardInputAllowed = true;
+        closeDialog();
+        await onEnable();
+      } catch (e, st) {
+        debugPrint('Failed to enable Wayland keyboard input consent: $e');
+        debugPrintStack(stackTrace: st);
+        if (!dialogClosed) {
+          consentInProgress = false;
+          safeSetState(() {});
+        }
+        return;
+      }
+    }
+
+    void cancel() {
+      if (consentInProgress) {
+        return;
+      }
+      closeDialog();
+    }
+
+    return CustomAlertDialog(
+      title: null,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          msgboxContent(
+            'warning',
+            'wayland-keyboard-input-disabled-tip',
+            'wayland-keyboard-input-consent-tip',
+          ),
+          const SizedBox(height: 6),
+          createDialogContent(kWaylandKeyboardIssueUrl).marginOnly(bottom: 6),
+          CheckboxListTile(
+            value: dontAskAgainForConnection,
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            controlAffinity: ListTileControlAffinity.leading,
+            title: Text(translate('dont-ask-again-for-this-connection-tip')),
+            onChanged: (v) {
+              setState(() => dontAskAgainForConnection = v == true);
+            },
+          ),
+          CheckboxListTile(
+            value: remember,
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            controlAffinity: ListTileControlAffinity.leading,
+            title: Text(translate('remember-wayland-keyboard-choice-tip')),
+            onChanged: (v) {
+              setState(() => remember = v == true);
+            },
+          ),
+        ],
+      ),
+      actions: [
+        dialogButton(
+          'Cancel',
+          onPressed: consentInProgress ? null : cancel,
+          isOutline: true,
+        ),
+        dialogButton(
+          'Enable',
+          onPressed:
+              consentInProgress ? null : () => unawaited(enableAndContinue()),
+        ),
+      ],
+      onCancel: consentInProgress ? null : cancel,
+      onSubmit: consentInProgress ? null : () => unawaited(enableAndContinue()),
+    );
+  }, clickMaskDismiss: false, backDismiss: false);
+  unawaited(dialogFuture.whenComplete(() => dialogClosed = true));
+}
+
 List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
   final ffiModel = ffi.ffiModel;
   final pi = ffiModel.pi;
   final perms = ffiModel.permissions;
   final sessionId = ffi.sessionId;
   final isDefaultConn = ffi.connType == ConnType.defaultConn;
+  final isWaylandPeer = pi.platform == kPeerPlatformLinux && pi.isWayland;
 
   List<TTextMenu> v = [];
   // elevation
@@ -142,11 +296,31 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     v.add(TTextMenu(
         child: Text(translate('Send clipboard keystrokes')),
         onPressed: () async {
-          ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
-          if (data != null && data.text != null) {
-            bind.sessionInputString(
-                sessionId: sessionId, value: data.text ?? "");
+          Future<void> sendClipboardKeystrokes() async {
+            ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
+            if (data != null && data.text != null) {
+              bind.sessionInputString(
+                  sessionId: sessionId, value: data.text ?? "");
+            }
           }
+
+          final allowWaylandKeyboard =
+              mainGetPeerBoolOptionSync(id, kPeerOptionAllowWaylandKeyboard);
+          if (shouldShowWaylandKeyboardPrompt(
+            connectionId: sessionId.toString(),
+            isWaylandPeer: isWaylandPeer,
+            allowWaylandKeyboardRemembered: allowWaylandKeyboard,
+          )) {
+            ffi.inputModel.keyboardInputAllowed = false;
+            showWaylandKeyboardInputWarningDialog(
+              id: id,
+              connectionId: sessionId.toString(),
+              ffi: ffi,
+              onEnable: sendClipboardKeystrokes,
+            );
+            return;
+          }
+          await sendClipboardKeystrokes();
         }));
   }
   // reset canvas
@@ -154,6 +328,23 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     v.add(TTextMenu(
         child: Text(translate('Reset canvas')),
         onPressed: () => ffi.cursorModel.reset()));
+  }
+  if (isDefaultConn && isWaylandPeer) {
+    v.add(TTextMenu(
+        child: Text(translate('wayland-keyboard-input-reset-remembered-tip')),
+        onPressed: () async {
+          await bind.mainSetPeerOption(
+              id: id,
+              key: kPeerOptionAllowWaylandKeyboard,
+              value: bool2option(kPeerOptionAllowWaylandKeyboard, false));
+          clearWaylandKeyboardPromptSuppressedForConnection(
+              sessionId.toString());
+          ffi.inputModel.keyboardInputAllowed = false;
+          if (isMobile) {
+            await ffi.invokeMethod("enable_soft_keyboard", false);
+          }
+          showToast(translate('Successful'));
+        }));
   }
 
   // https://github.com/rustdesk/rustdesk/pull/9731

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -101,6 +101,9 @@ class _RemotePageState extends State<RemotePage>
   Function(bool)? _onEnterOrLeaveImage4Toolbar;
 
   late FFI _ffi;
+  Worker? _waylandKeyboardModeWorker;
+  bool _waylandKeyboardModeNormalized = false;
+  bool _waylandKeyboardModeNormalizing = false;
 
   SessionID get sessionId => _ffi.sessionId;
 
@@ -178,6 +181,48 @@ class _RemotePageState extends State<RemotePage>
     // Register callback to cancel debounce timer when relative mouse mode is disabled
     _ffi.inputModel.onRelativeMouseModeDisabled =
         _cancelPointerLockCenterDebounceTimer;
+
+    _waylandKeyboardModeWorker = ever(_ffi.ffiModel.pi.isSet, (bool isSet) {
+      if (isSet) {
+        unawaited(_normalizeWaylandKeyboardModeIfNeeded());
+      }
+    });
+    if (_ffi.ffiModel.pi.isSet.value) {
+      unawaited(_normalizeWaylandKeyboardModeIfNeeded());
+    }
+  }
+
+  Future<void> _normalizeWaylandKeyboardModeIfNeeded() async {
+    if (!mounted ||
+        _waylandKeyboardModeNormalized ||
+        _waylandKeyboardModeNormalizing) {
+      return;
+    }
+    _waylandKeyboardModeNormalizing = true;
+    try {
+      final pi = _ffi.ffiModel.pi;
+      if (pi.platform != kPeerPlatformLinux || !pi.isWayland) return;
+      final mapSupported = bind.sessionIsKeyboardModeSupported(
+          sessionId: sessionId, mode: kKeyMapMode);
+      if (!mapSupported) return;
+      final current = await bind.sessionGetKeyboardMode(sessionId: sessionId);
+      if (!mounted) return;
+      if (current == kKeyMapMode) {
+        _waylandKeyboardModeNormalized = true;
+        return;
+      }
+      await bind.sessionSetKeyboardMode(
+          sessionId: sessionId, value: kKeyMapMode);
+      if (!mounted) return;
+      await _ffi.inputModel.updateKeyboardMode();
+      if (!mounted) return;
+      _waylandKeyboardModeNormalized = true;
+    } catch (e, st) {
+      debugPrint('Failed to normalize Wayland keyboard mode: $e');
+      debugPrintStack(stackTrace: st);
+    } finally {
+      _waylandKeyboardModeNormalizing = false;
+    }
   }
 
   /// Cancel the pointer lock center debounce timer
@@ -318,6 +363,7 @@ class _RemotePageState extends State<RemotePage>
 
     _pointerLockCenterDebounceTimer?.cancel();
     _pointerLockCenterDebounceTimer = null;
+    _waylandKeyboardModeWorker?.dispose();
     // Clear callback reference to prevent memory leaks and stale references
     _ffi.inputModel.onRelativeMouseModeDisabled = null;
     // Relative mouse mode cleanup is centralized in FFI.close(closeSession: ...).
@@ -331,6 +377,9 @@ class _RemotePageState extends State<RemotePage>
     _ffi.imageModel.disposeImage();
     _ffi.cursorModel.disposeImages();
     _rawKeyFocusNode.dispose();
+    if (closeSession) {
+      clearWaylandKeyboardPromptSuppressedForConnection(sessionId.toString());
+    }
     await _ffi.close(closeSession: closeSession);
     _timer?.cancel();
     _ffi.dialogManager.dismissAll();

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1861,18 +1861,8 @@ class _KeyboardMenu extends StatelessWidget {
           continue;
         }
 
-        if (pi.isWayland) {
-          // Legacy mode is hidden on desktop control side because dead keys
-          // don't work properly on Wayland. When the control side is mobile,
-          // Legacy mode is used automatically (mobile always sends Legacy events).
-          if (mode.key == kKeyLegacyMode) {
-            continue;
-          }
-          // Translate mode requires server >= 1.4.6.
-          if (mode.key == kKeyTranslateMode &&
-              versionCmp(pi.version, '1.4.6') < 0) {
-            continue;
-          }
+        if (pi.isWayland && mode.key != kKeyMapMode) {
+          continue;
         }
 
         var text = translate(mode.menu);

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -75,6 +75,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   final FocusNode _physicalFocusNode = FocusNode();
   var _showEdit = false; // use soft keyboard
 
+  Worker? _waylandKeyboardGateWorker;
+  bool _waylandKeyboardGateInitialized = false;
+
   InputModel get inputModel => gFFI.inputModel;
   SessionID get sessionId => gFFI.sessionId;
 
@@ -121,6 +124,20 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
           isKeyboardVisible: keyboardVisibilityController.isVisible);
     });
     WidgetsBinding.instance.addObserver(this);
+
+    inputModel.keyboardInputAllowed = true;
+
+    // Wayland sessions may use clipboard-based text input on the controlled side.
+    // Require explicit user confirmation before allowing soft-keyboard and
+    // clipboard-assisted text input. Physical keyboard events are not gated here.
+    _waylandKeyboardGateWorker = ever(gFFI.ffiModel.pi.isSet, (bool isSet) {
+      if (isSet) {
+        _initWaylandKeyboardGateIfNeeded();
+      }
+    });
+    if (gFFI.ffiModel.pi.isSet.value) {
+      _initWaylandKeyboardGateIfNeeded();
+    }
   }
 
   @override
@@ -135,6 +152,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     await gFFI.invokeMethod("enable_soft_keyboard", true);
     _mobileFocusNode.dispose();
     _physicalFocusNode.dispose();
+    clearWaylandKeyboardPromptSuppressedForConnection(sessionId.toString());
+    _waylandKeyboardGateWorker?.dispose();
+    inputModel.keyboardInputAllowed = true;
     await gFFI.close();
     _timer?.cancel();
     _iosKeyboardWorkaroundTimer?.cancel();
@@ -161,6 +181,40 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   // When swithing from other app to this app, try to sync clipboard.
   void trySyncClipboard() {
     gFFI.invokeMethod("try_sync_clipboard");
+  }
+
+  bool _shouldGateKeyboardForWayland() {
+    if (!(isAndroid || isIOS)) return false;
+    final pi = gFFI.ffiModel.pi;
+    return pi.platform == kPeerPlatformLinux && pi.isWayland;
+  }
+
+  void _initWaylandKeyboardGateIfNeeded() {
+    if (!mounted) return;
+    if (_waylandKeyboardGateInitialized) return;
+    if (!_shouldGateKeyboardForWayland()) return;
+
+    _waylandKeyboardGateInitialized = true;
+
+    final allowWaylandKeyboard =
+        mainGetPeerBoolOptionSync(widget.id, kPeerOptionAllowWaylandKeyboard);
+    if (!shouldShowWaylandKeyboardPrompt(
+      connectionId: sessionId.toString(),
+      isWaylandPeer: _shouldGateKeyboardForWayland(),
+      allowWaylandKeyboardRemembered: allowWaylandKeyboard,
+    )) {
+      inputModel.keyboardInputAllowed = true;
+      return;
+    }
+
+    inputModel.keyboardInputAllowed = false;
+
+    // Ensure soft keyboard is not active before user confirms.
+    _showEdit = false;
+    gFFI.invokeMethod("enable_soft_keyboard", false);
+    _mobileFocusNode.unfocus();
+    _physicalFocusNode.requestFocus();
+    setState(() {});
   }
 
   // to-do: It should be better to use transparent color instead of the bgColor.
@@ -294,7 +348,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                 content == '【】')) {
           // can not only input content[0], because when input ], [ are also auo insert, which cause ] never be input
           bind.sessionInputString(sessionId: sessionId, value: content);
-          openKeyboard();
+          _openKeyboardUnlocked();
           return;
         }
         bind.sessionInputString(sessionId: sessionId, value: content);
@@ -306,6 +360,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
 
   // handle mobile virtual keyboard
   void handleSoftKeyboardInput(String newValue) {
+    if (!inputModel.keyboardInputAllowed) {
+      return;
+    }
     if (isIOS) {
       _handleIOSSoftKeyboardInput(newValue);
     } else {
@@ -314,6 +371,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   }
 
   void inputChar(String char) {
+    if (!inputModel.keyboardInputAllowed) {
+      return;
+    }
     if (char == '\n') {
       char = 'VK_RETURN';
     } else if (char == ' ') {
@@ -323,6 +383,29 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   }
 
   void openKeyboard() {
+    final allowWaylandKeyboard =
+        mainGetPeerBoolOptionSync(widget.id, kPeerOptionAllowWaylandKeyboard);
+    if (shouldShowWaylandKeyboardPrompt(
+      connectionId: sessionId.toString(),
+      isWaylandPeer: _shouldGateKeyboardForWayland(),
+      allowWaylandKeyboardRemembered: allowWaylandKeyboard,
+    )) {
+      inputModel.keyboardInputAllowed = false;
+      showWaylandKeyboardInputWarningDialog(
+        id: widget.id,
+        connectionId: sessionId.toString(),
+        ffi: gFFI,
+        onEnable: () async {
+          _openKeyboardUnlocked();
+        },
+      );
+      return;
+    }
+    _openKeyboardUnlocked();
+  }
+
+  void _openKeyboardUnlocked() {
+    inputModel.keyboardInputAllowed = true;
     gFFI.invokeMethod("enable_soft_keyboard", true);
     // destroy first, so that our _value trick can work
     _value = initText;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -396,6 +396,10 @@ class InputModel {
 
   late final SessionID sessionId;
 
+  // Local gate for clipboard-assisted input flows on mobile Wayland dialogs.
+  // It should not block physical keyboard events.
+  bool keyboardInputAllowed = true;
+
   bool get keyboardPerm => parent.target!.ffiModel.keyboard;
   String get id => parent.target?.id ?? '';
   String? get peerPlatform => parent.target?.ffiModel.pi.platform;

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,5 +1,7 @@
 #[cfg(not(target_os = "android"))]
 use arboard::{ClipboardData, ClipboardFormat};
+#[cfg(target_os = "linux")]
+use arboard::{LinuxClipboardKind, SetExtLinux};
 use hbb_common::{bail, log, message_proto::*, ResultType};
 use std::{
     sync::{Arc, Mutex},
@@ -54,6 +56,43 @@ pub fn check_clipboard(
     side: ClipboardSide,
     force: bool,
 ) -> Option<Message> {
+    let (msg, clipboards) = read_clipboard_message(ctx, side, force)?;
+    *LAST_MULTI_CLIPBOARDS.lock().unwrap() = clipboards;
+    Some(msg)
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn peek_clipboard(
+    ctx: &mut Option<ClipboardContext>,
+    side: ClipboardSide,
+    force: bool,
+) -> Option<Message> {
+    let (msg, _) = read_clipboard_message(ctx, side, force)?;
+    Some(msg)
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn cache_clipboard_msg(msg: &Message) {
+    match &msg.union {
+        Some(message::Union::MultiClipboards(multi_clipboards)) => {
+            *LAST_MULTI_CLIPBOARDS.lock().unwrap() = multi_clipboards.clone();
+        }
+        Some(message::Union::Clipboard(clipboard)) => {
+            *LAST_MULTI_CLIPBOARDS.lock().unwrap() = MultiClipboards {
+                clipboards: vec![clipboard.clone()],
+                ..Default::default()
+            };
+        }
+        _ => {}
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn read_clipboard_message(
+    ctx: &mut Option<ClipboardContext>,
+    side: ClipboardSide,
+    force: bool,
+) -> Option<(Message, MultiClipboards)> {
     if ctx.is_none() {
         *ctx = ClipboardContext::new().ok();
     }
@@ -64,8 +103,7 @@ pub fn check_clipboard(
                 let mut msg = Message::new();
                 let clipboards = proto::create_multi_clipboards(content);
                 msg.set_multi_clipboards(clipboards.clone());
-                *LAST_MULTI_CLIPBOARDS.lock().unwrap() = clipboards;
-                return Some(msg);
+                return Some((msg, clipboards));
             }
         }
         Err(e) => {
@@ -219,16 +257,36 @@ fn do_update_clipboard_(mut to_update_data: Vec<ClipboardData>, side: ClipboardS
         }
     }
     if let Some(ctx) = ctx.as_mut() {
-        to_update_data.push(ClipboardData::Special((
-            RUSTDESK_CLIPBOARD_OWNER_FORMAT.to_owned(),
-            side.get_owner_data(),
-        )));
+        to_update_data = append_owner_marker(to_update_data, side);
         if let Err(e) = ctx.set(&to_update_data) {
             log::debug!("Failed to set clipboard: {}", e);
         } else {
             log::debug!("{} updated on {}", CLIPBOARD_NAME, side);
         }
     }
+}
+
+#[cfg(not(target_os = "android"))]
+fn append_owner_marker(mut data: Vec<ClipboardData>, side: ClipboardSide) -> Vec<ClipboardData> {
+    data.push(ClipboardData::Special((
+        RUSTDESK_CLIPBOARD_OWNER_FORMAT.to_owned(),
+        side.get_owner_data(),
+    )));
+    data
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_text_clipboard_with_owner_sync(text: &str, side: ClipboardSide) -> ResultType<()> {
+    let mut ctx = CLIPBOARD_CTX.lock().unwrap();
+    if ctx.is_none() {
+        *ctx = Some(ClipboardContext::new()?);
+    }
+    let clipboard_ctx = match ctx.as_mut() {
+        Some(ctx) => ctx,
+        None => bail!("Failed to create clipboard context"),
+    };
+    let data = append_owner_marker(vec![ClipboardData::Text(text.to_owned())], side);
+    clipboard_ctx.set_with_owner_marker_for_linux(&data)
 }
 
 #[cfg(not(target_os = "android"))]
@@ -379,6 +437,24 @@ impl ClipboardContext {
     fn set(&mut self, data: &[ClipboardData]) -> ResultType<()> {
         let _lock = ARBOARD_MTX.lock().unwrap();
         self.inner.set_formats(data)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_with_owner_marker_for_linux(&mut self, data: &[ClipboardData]) -> ResultType<()> {
+        let _lock = ARBOARD_MTX.lock().unwrap();
+        self.inner
+            .set()
+            .clipboard(LinuxClipboardKind::Clipboard)
+            .formats(data)?;
+        if let Err(e) = self
+            .inner
+            .set()
+            .clipboard(LinuxClipboardKind::Primary)
+            .formats(data)
+        {
+            log::warn!("Failed to set PRIMARY clipboard with owner marker: {}", e);
+        }
         Ok(())
     }
 

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "اسم العرض"),
         ("password-hidden-tip", "كلمة المرور مخفية"),
         ("preset-password-in-use-tip", "كلمة المرور المحددة مسبقًا قيد الاستخدام"),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "显示名称"),
         ("password-hidden-tip", "永久密码已设置（已隐藏）"),
         ("preset-password-in-use-tip", "当前使用预设密码"),
+        ("wayland-keyboard-input-disabled-tip", "键盘输入已禁用"),
+        ("wayland-keyboard-input-consent-tip", "此远程会话使用 Wayland。使用软键盘输入时，RustDesk 在某些情况下会先写入被控端剪贴板再粘贴，输入内容可能被剪贴板历史或其他应用看到。继续后，将启用键盘输入。详见："),
+        ("wayland-keyboard-input-reset-remembered-tip", "重置已记住的 Wayland 键盘选择"),
+        ("dont-ask-again-for-this-connection-tip", "此连接期间不再询问"),
+        ("remember-wayland-keyboard-choice-tip", "为此设备记住此选择"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Anzeigename"),
         ("password-hidden-tip", "Ein permanentes Passwort wurde festgelegt (ausgeblendet)."),
         ("preset-password-in-use-tip", "Das voreingestellte Passwort wird derzeit verwendet."),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Εμφανιζόμενο όνομα"),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -274,5 +274,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-incoming-sessions-label", "Keep screen awake during incoming sessions"),
         ("password-hidden-tip", "Permanent password is set (hidden)."),
         ("preset-password-in-use-tip", "Preset password is currently in use."),
+        ("wayland-keyboard-input-disabled-tip", "Keyboard input disabled"),
+        ("wayland-keyboard-input-consent-tip", "This remote session uses Wayland. For on-screen keyboard input, RustDesk may write text to the remote clipboard and paste it. This may expose what you type to clipboard history or other apps. If you continue, keyboard input will be enabled. See issue:"),
+        ("wayland-keyboard-input-reset-remembered-tip", "Reset remembered Wayland keyboard choice"),
+        ("dont-ask-again-for-this-connection-tip", "Don't ask again for this connection"),
+        ("remember-wayland-keyboard-choice-tip", "Remember this choice on this device"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Nom d’affichage"),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Kijelző név"),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Visualizza nome"),
         ("password-hidden-tip", "È impostata una password permanente (nascosta)."),
         ("preset-password-in-use-tip", "È attualmente in uso la password preimpostata."),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "표시 이름"),
         ("password-hidden-tip", "영구 비밀번호가 설정되었습니다 (숨김)."),
         ("preset-password-in-use-tip", "현재 사전 설정된 비밀번호가 사용 중입니다."),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Naam Weergeven"),
         ("password-hidden-tip", "Er is een permanent wachtwoord ingesteld (verborgen)."),
         ("preset-password-in-use-tip", "Het basis wachtwoord is momenteel in gebruik."),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Отображаемое имя"),
         ("password-hidden-tip", "Установлен постоянный пароль (скрытый)."),
         ("preset-password-in-use-tip", "Установленный пароль сейчас используется."),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "Görünen Ad"),
         ("password-hidden-tip", "Şifre gizli"),
         ("preset-password-in-use-tip", "Önceden ayarlanmış şifre kullanılıyor"),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "顯示名稱"),
         ("password-hidden-tip", "固定密碼已設定（已隱藏）"),
         ("preset-password-in-use-tip", "目前正在使用預設密碼"),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -743,5 +743,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", ""),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("wayland-keyboard-input-disabled-tip", ""),
+        ("wayland-keyboard-input-consent-tip", ""),
+        ("wayland-keyboard-input-reset-remembered-tip", ""),
+        ("dont-ask-again-for-this-connection-tip", ""),
+        ("remember-wayland-keyboard-choice-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -2,7 +2,7 @@ use super::*;
 #[cfg(not(target_os = "android"))]
 use crate::clipboard::clipboard_listener;
 #[cfg(not(target_os = "android"))]
-pub use crate::clipboard::{check_clipboard, ClipboardContext, ClipboardSide};
+pub use crate::clipboard::{ClipboardContext, ClipboardSide};
 pub use crate::clipboard::{CLIPBOARD_INTERVAL as INTERVAL, CLIPBOARD_NAME as NAME};
 #[cfg(windows)]
 use crate::ipc::{self, ClipboardFile, ClipboardNonFile, Data};
@@ -109,6 +109,63 @@ fn run(sp: EmptyExtraFieldService) -> ResultType<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+const WAYLAND_CLIPBOARD_SKIP_CHECK_MAX_UTF8_BYTES: usize =
+    super::input_service::WAYLAND_CLIPBOARD_INPUT_MAX_TEXT_CHARS * 4;
+
+#[cfg(target_os = "linux")]
+fn decode_utf8_prefix(bytes: &[u8]) -> Option<String> {
+    let mut end = bytes.len().min(WAYLAND_CLIPBOARD_SKIP_CHECK_MAX_UTF8_BYTES);
+    loop {
+        match std::str::from_utf8(&bytes[..end]) {
+            Ok(text) => return Some(text.to_owned()),
+            Err(e) => {
+                if e.error_len().is_some() {
+                    return None;
+                }
+                if end == 0 {
+                    return Some(String::new());
+                }
+                end -= 1;
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn decode_text_clipboard(clipboard: &Clipboard) -> Option<String> {
+    if clipboard.format.enum_value() != Ok(ClipboardFormat::Text) {
+        return None;
+    }
+    if clipboard.compress {
+        let bytes = hbb_common::compress::decompress(&clipboard.content);
+        return decode_utf8_prefix(&bytes);
+    }
+    decode_utf8_prefix(&clipboard.content)
+}
+
+#[cfg(target_os = "linux")]
+fn should_skip_wayland_clipboard_sync(msg: &Message) -> bool {
+    if crate::platform::linux::is_x11() {
+        return false;
+    }
+    let is_recent_wayland_input = |clipboard: &Clipboard| -> bool {
+        let Some(text) = decode_text_clipboard(clipboard) else {
+            return false;
+        };
+        super::input_service::is_recent_wayland_clipboard_input(&text)
+    };
+
+    match &msg.union {
+        Some(message::Union::Clipboard(clipboard)) => is_recent_wayland_input(clipboard),
+        Some(message::Union::MultiClipboards(multi_clipboards)) => multi_clipboards
+            .clipboards
+            .iter()
+            .any(is_recent_wayland_input),
+        _ => false,
+    }
+}
+
 #[cfg(not(target_os = "android"))]
 impl Handler {
     #[cfg(feature = "unix-file-copy-paste")]
@@ -172,7 +229,20 @@ impl Handler {
             }
         }
 
-        check_clipboard(&mut self.ctx, ClipboardSide::Host, false)
+        #[cfg(target_os = "linux")]
+        {
+            let msg = crate::clipboard::peek_clipboard(&mut self.ctx, ClipboardSide::Host, false)?;
+            if should_skip_wayland_clipboard_sync(&msg) {
+                log::debug!("Skip clipboard sync for recent Wayland keyboard injection");
+                return None;
+            }
+            crate::clipboard::cache_clipboard_msg(&msg);
+            return Some(msg);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            crate::clipboard::check_clipboard(&mut self.ctx, ClipboardSide::Host, false)
+        }
     }
 
     // Read clipboard data from cm using ipc.

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -457,6 +457,12 @@ lazy_static::lazy_static! {
     static ref RELATIVE_MOUSE_CONNS: Arc<Mutex<std::collections::HashSet<i32>>> = Default::default();
 }
 
+#[cfg(target_os = "linux")]
+lazy_static::lazy_static! {
+    static ref WAYLAND_CLIPBOARD_INPUT_RECORDS: Arc<Mutex<Vec<(Instant, String)>>> =
+        Default::default();
+}
+
 #[inline]
 fn set_relative_mouse_active(conn: i32, active: bool) {
     let mut lock = RELATIVE_MOUSE_CONNS.lock().unwrap();
@@ -1668,40 +1674,103 @@ fn process_seq(en: &mut Enigo, sequence: &str) {
 /// this delay may be insufficient, but there is no reliable alternative mechanism.
 #[cfg(target_os = "linux")]
 const CLIPBOARD_SYNC_DELAY_MS: u64 = 50;
+#[cfg(target_os = "linux")]
+const WAYLAND_CLIPBOARD_INPUT_FILTER_WINDOW: Duration = Duration::from_secs(1);
+#[cfg(target_os = "linux")]
+const WAYLAND_CLIPBOARD_INPUT_MAX_RECORDS: usize = 256;
+#[cfg(target_os = "linux")]
+pub(super) const WAYLAND_CLIPBOARD_INPUT_MAX_TEXT_CHARS: usize = 1024;
+
+#[cfg(target_os = "linux")]
+fn cleanup_wayland_clipboard_input_records(records: &mut Vec<(Instant, String)>, now: Instant) {
+    records.retain(|(created_at, _)| {
+        now.saturating_duration_since(*created_at) <= WAYLAND_CLIPBOARD_INPUT_FILTER_WINDOW
+    });
+    let len = records.len();
+    if len > WAYLAND_CLIPBOARD_INPUT_MAX_RECORDS {
+        records.drain(0..(len - WAYLAND_CLIPBOARD_INPUT_MAX_RECORDS));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn normalize_wayland_clipboard_input_text(text: &str) -> String {
+    text.chars()
+        .take(WAYLAND_CLIPBOARD_INPUT_MAX_TEXT_CHARS)
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn get_wayland_clipboard_input_normalized_text(text: &str) -> Option<String> {
+    let normalized = normalize_wayland_clipboard_input_text(text);
+    if normalized.is_empty() {
+        return None;
+    }
+    Some(normalized)
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn record_wayland_clipboard_input_for_sync_filter(text: &str) -> Option<(Instant, String)> {
+    if text.is_empty() || crate::platform::linux::is_x11() {
+        return None;
+    }
+    let normalized = get_wayland_clipboard_input_normalized_text(text)?;
+    let now = Instant::now();
+    let mut records = WAYLAND_CLIPBOARD_INPUT_RECORDS.lock().unwrap();
+    cleanup_wayland_clipboard_input_records(&mut records, now);
+    records.push((now, normalized.clone()));
+    Some((now, normalized))
+}
+
+#[cfg(target_os = "linux")]
+#[inline]
+fn rollback_wayland_clipboard_input_record(record: (Instant, String)) {
+    let (created_at, normalized) = record;
+    let now = Instant::now();
+    let mut records = WAYLAND_CLIPBOARD_INPUT_RECORDS.lock().unwrap();
+    cleanup_wayland_clipboard_input_records(&mut records, now);
+    if let Some(pos) = records
+        .iter()
+        .rposition(|(record_created_at, record_normalized)| {
+            *record_created_at == created_at && *record_normalized == normalized
+        })
+    {
+        records.remove(pos);
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn is_recent_wayland_clipboard_input(text: &str) -> bool {
+    if text.is_empty() || crate::platform::linux::is_x11() {
+        return false;
+    }
+    let Some(normalized) = get_wayland_clipboard_input_normalized_text(text) else {
+        return false;
+    };
+    let now = Instant::now();
+    let mut records = WAYLAND_CLIPBOARD_INPUT_RECORDS.lock().unwrap();
+    cleanup_wayland_clipboard_input_records(&mut records, now);
+    records
+        .iter()
+        .any(|(_, record_normalized)| record_normalized == &normalized)
+}
 
 /// Internal: Set clipboard content without delay.
 /// Returns true if clipboard was set successfully.
 #[cfg(target_os = "linux")]
 fn set_clipboard_content(text: &str) -> bool {
-    use arboard::{Clipboard, LinuxClipboardKind, SetExtLinux};
-
-    let mut clipboard = match Clipboard::new() {
-        Ok(cb) => cb,
-        Err(e) => {
-            log::error!("set_clipboard_content: failed to create clipboard: {:?}", e);
-            return false;
-        }
-    };
-
-    // Set both CLIPBOARD and PRIMARY selections
-    // Terminal uses PRIMARY for Shift+Insert, GUI apps use CLIPBOARD
-    if let Err(e) = clipboard
-        .set()
-        .clipboard(LinuxClipboardKind::Clipboard)
-        .text(text.to_owned())
-    {
-        log::error!("set_clipboard_content: failed to set CLIPBOARD: {:?}", e);
+    if let Err(e) = crate::clipboard::set_text_clipboard_with_owner_sync(
+        text,
+        crate::clipboard::ClipboardSide::Host,
+    ) {
+        log::error!(
+            "set_clipboard_content: failed to set clipboard with owner marker: {:?}",
+            e
+        );
         return false;
     }
-    if let Err(e) = clipboard
-        .set()
-        .clipboard(LinuxClipboardKind::Primary)
-        .text(text.to_owned())
-    {
-        log::warn!("set_clipboard_content: failed to set PRIMARY: {:?}", e);
-        // Continue anyway, CLIPBOARD might work
-    }
-
     true
 }
 
@@ -1714,7 +1783,11 @@ fn set_clipboard_content(text: &str) -> bool {
 #[cfg(target_os = "linux")]
 #[inline]
 pub(super) fn set_clipboard_for_paste_sync(text: &str) -> bool {
+    let record = record_wayland_clipboard_input_for_sync_filter(text);
     if !set_clipboard_content(text) {
+        if let Some(record) = record {
+            rollback_wayland_clipboard_input_record(record);
+        }
         return false;
     }
     std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_SYNC_DELAY_MS));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wayland keyboard gating: consent dialog before on-screen-keyboard input with “Enable/Cancel”, “don’t ask again” (per-connection) and “remember” options; toolbar action to reset remembered/suppression.

* **Behavior**
  * Clipboard sync now suppresses recent Wayland-injected clipboard text to avoid accidental pastes. Mobile soft keyboard and desktop keyboard modes are gated/normalized for Wayland peers.

* **Localization**
  * Added Wayland keyboard prompt strings across 40+ languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->