### PR TITLE
Fix/linux x11 keyboard grab race

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -615,9 +615,9 @@ pub fn session_enter_or_leave(_session_id: SessionID, _enter: bool) -> SyncRetur
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Some(session) = sessions::get_session_by_session_id(&_session_id) {
         let keyboard_mode = session.get_keyboard_mode();
-        // Use the per-window UUID (not lc.session_id which is per-connection)
+        // Use the full per-window UUID (not lc.session_id which is per-connection)
         // so that two windows viewing the same peer get distinct grab owners.
-        let window_id = _session_id.as_u128() as u64;
+        let window_id = _session_id.as_u128();
         if _enter {
             set_cur_session_id_(_session_id, &keyboard_mode);
             crate::keyboard::client::change_grab_status(

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -615,11 +615,22 @@ pub fn session_enter_or_leave(_session_id: SessionID, _enter: bool) -> SyncRetur
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Some(session) = sessions::get_session_by_session_id(&_session_id) {
         let keyboard_mode = session.get_keyboard_mode();
+        // Use the per-window UUID (not lc.session_id which is per-connection)
+        // so that two windows viewing the same peer get distinct grab owners.
+        let window_id = _session_id.as_u128() as u64;
         if _enter {
             set_cur_session_id_(_session_id, &keyboard_mode);
-            session.enter(keyboard_mode);
+            crate::keyboard::client::change_grab_status(
+                crate::common::GrabState::Run,
+                &keyboard_mode,
+                window_id,
+            );
         } else {
-            session.leave(keyboard_mode);
+            crate::keyboard::client::change_grab_status(
+                crate::common::GrabState::Wait,
+                &keyboard_mode,
+                window_id,
+            );
         }
     }
     SyncReturn(())

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -84,11 +84,16 @@ pub mod client {
 
     /// Tracks grab ownership and serializes transitions across threads.
     ///
-    /// On Linux/X11, `XGrabKeyboard` can cause a focus-change feedback loop:
-    /// grab -> focus shifts -> PointerExit -> ungrab -> focus returns ->
-    /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
-    /// spurious `Wait` events that arrive shortly after a `Run` for the same
-    /// session - these are X11 focus feedback, not real user actions.
+    /// Multiple Flutter isolates (one per session window) call
+    /// `change_grab_status(Run/Wait)` concurrently. Without serialization a
+    /// stale `Wait` from session A can clobber session B's freshly acquired
+    /// grab on any desktop OS.
+    ///
+    /// Windows and macOS are less susceptible in practice because the Flutter
+    /// side triggers `enterView` only after a mouse click inside the window,
+    /// but we cannot rely on that. On Linux/X11, `XGrabKeyboard` can also
+    /// cause a focus-change feedback loop (~10 Hz), so `last_grab` debounces
+    /// spurious `Wait` events that arrive shortly after a `Run`.
     #[derive(Default)]
     struct GrabOwnerState {
         owner: Option<u64>,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -82,8 +82,31 @@ lazy_static::lazy_static! {
 pub mod client {
     use super::*;
 
+    /// Tracks grab ownership and serializes transitions across threads.
+    ///
+    /// On Linux/X11, `XGrabKeyboard` can cause a focus-change feedback loop:
+    /// grab -> focus shifts -> PointerExit -> ungrab -> focus returns ->
+    /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
+    /// spurious `Wait` events that arrive shortly after a `Run` for the same
+    /// session - these are X11 focus feedback, not real user actions.
+    struct GrabOwnerState {
+        owner: Option<u64>,
+        last_grab: Option<std::time::Instant>,
+    }
+
+    impl Default for GrabOwnerState {
+        fn default() -> Self {
+            Self { owner: None, last_grab: None }
+        }
+    }
+
+    /// How long after a grab acquisition we suppress Wait from the same session.
+    /// Must exceed one full X11 feedback cycle (~100 ms: 50 ms enable + 50 ms disable).
+    const GRAB_DEBOUNCE_MS: u128 = 300;
+
     lazy_static::lazy_static! {
         static ref IS_GRAB_STARTED: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+        static ref GRAB_STATE: Arc<Mutex<GrabOwnerState>> = Arc::new(Mutex::new(GrabOwnerState::default()));
     }
 
     pub fn start_grab_loop() {
@@ -96,33 +119,98 @@ pub mod client {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn change_grab_status(state: GrabState, keyboard_mode: &str) {
+    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u64) {
         #[cfg(feature = "flutter")]
         if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
             return;
         }
+        // Serialize transitions so a stale `Wait` from a previous owner cannot
+        // clobber a fresh `Run` from a different session window.
+        let mut gs = GRAB_STATE.lock().unwrap();
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
                 #[cfg(windows)]
                 update_grab_get_key_name(keyboard_mode);
+
+                // Idempotent: if this session already owns the grab, just
+                // refresh the debounce timer (proves the session is still
+                // actively focused) and skip the actual grab call.
+                if gs.owner == Some(session_id) {
+                    gs.last_grab = Some(std::time::Instant::now());
+                    log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
+                    return;
+                }
+
+                log::info!(
+                    "[grab] Run(0x{:x}): prev_owner={}, mode={}",
+                    session_id,
+                    gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    keyboard_mode,
+                );
+
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-                KEYBOARD_HOOKED.swap(true, Ordering::SeqCst);
+                KEYBOARD_HOOKED.store(true, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
-                rdev::enable_grab();
+                {
+                    // On handoff, explicitly release any prior owner's X11 grab
+                    // before taking our own. This keeps the rdev control thread
+                    // and the X server in a consistent state even if the prior
+                    // owner never sent `Wait` (e.g. disconnected or raced).
+                    if gs.owner.is_some() {
+                        log::info!("[grab] handoff: disable_grab before re-grab");
+                        rdev::disable_grab();
+                    }
+                    rdev::enable_grab();
+                }
+                gs.owner = Some(session_id);
+                gs.last_grab = Some(std::time::Instant::now());
             }
             GrabState::Wait => {
+                // Drop stale `Wait` events that do not correspond to the
+                // current grab owner. This prevents a late PointerExit from
+                // session A from releasing session B's freshly acquired grab.
+                if gs.owner != Some(session_id) {
+                    log::debug!(
+                        "[grab] Wait(0x{:x}): ignored, owner={}",
+                        session_id,
+                        gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    );
+                    return;
+                }
+
+                // Debounce: on Linux/X11, XGrabKeyboard causes a focus-change
+                // feedback loop (grab -> PointerExit -> ungrab -> PointerEnter ->
+                // grab -> ...). Suppress Wait if the grab was acquired recently
+                // by this same session -- it is X11 feedback, not a real leave.
+                #[cfg(target_os = "linux")]
+                if let Some(t) = gs.last_grab {
+                    let elapsed = t.elapsed().as_millis();
+                    if elapsed < GRAB_DEBOUNCE_MS {
+                        log::debug!(
+                            "[grab] Wait(0x{:x}): debounced ({}ms < {}ms)",
+                            session_id, elapsed, GRAB_DEBOUNCE_MS,
+                        );
+                        return;
+                    }
+                }
+
+                log::info!("[grab] Wait(0x{:x}): releasing grab", session_id);
+
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
 
                 release_remote_keys(keyboard_mode);
 
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-                KEYBOARD_HOOKED.swap(false, Ordering::SeqCst);
+                KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
                 rdev::disable_grab();
+
+                gs.owner = None;
+                gs.last_grab = None;
             }
             GrabState::Exit => {}
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -211,9 +211,9 @@ pub mod client {
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
                                 let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
-                                gs.deferred_pending = false;
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                    gs.deferred_pending = false;
                                     log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
                                     release_remote_keys(&mode);
                                     KEYBOARD_HOOKED.store(false, Ordering::SeqCst);

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -105,6 +105,7 @@ pub mod client {
 
     /// How long after a grab acquisition we suppress Wait from the same session.
     /// Must exceed one full X11 feedback cycle (~100 ms: 50 ms enable + 50 ms disable).
+    #[cfg(target_os = "linux")]
     const GRAB_DEBOUNCE_MS: u128 = 300;
 
     lazy_static::lazy_static! {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -108,7 +108,7 @@ pub mod client {
     }
 
     pub fn start_grab_loop() {
-        let mut lock = IS_GRAB_STARTED.lock().unwrap();
+        let mut lock = IS_GRAB_STARTED.lock().unwrap_or_else(|e| e.into_inner());
         if *lock {
             return;
         }
@@ -124,7 +124,7 @@ pub mod client {
         }
         // Serialize transitions so a stale `Wait` from a previous owner cannot
         // clobber a fresh `Run` from a different session window.
-        let mut gs = GRAB_STATE.lock().unwrap();
+        let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
@@ -205,7 +205,7 @@ pub mod client {
                             let mode = keyboard_mode.to_string();
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
-                                let mut gs = GRAB_STATE.lock().unwrap();
+                                let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
                                 gs.deferred_pending = false;
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -89,18 +89,13 @@ pub mod client {
     /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
     /// spurious `Wait` events that arrive shortly after a `Run` for the same
     /// session - these are X11 focus feedback, not real user actions.
+    #[derive(Default)]
     struct GrabOwnerState {
         owner: Option<u64>,
         last_grab: Option<std::time::Instant>,
         /// True while a deferred-release thread is in flight. Prevents
         /// spawning redundant threads during the X11 feedback loop.
         deferred_pending: bool,
-    }
-
-    impl Default for GrabOwnerState {
-        fn default() -> Self {
-            Self { owner: None, last_grab: None, deferred_pending: false }
-        }
     }
 
     /// How long after a grab acquisition we suppress Wait from the same session.
@@ -141,6 +136,9 @@ pub mod client {
                 // actively focused) and skip the actual grab call.
                 if gs.owner == Some(session_id) {
                     gs.last_grab = Some(std::time::Instant::now());
+                    // Reset so the next Wait can spawn a fresh deferred-release
+                    // timer with an up-to-date snapshot of last_grab.
+                    gs.deferred_pending = false;
                     log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
                     return;
                 }
@@ -169,6 +167,9 @@ pub mod client {
                 }
                 gs.owner = Some(session_id);
                 gs.last_grab = Some(std::time::Instant::now());
+                // Invalidate any in-flight deferred release from the previous
+                // owner so it cannot suppress a fresh timer for the new owner.
+                gs.deferred_pending = false;
             }
             GrabState::Wait => {
                 // Drop stale `Wait` events that do not correspond to the

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -96,7 +96,7 @@ pub mod client {
     /// spurious `Wait` events that arrive shortly after a `Run`.
     #[derive(Default)]
     struct GrabOwnerState {
-        owner: Option<u64>,
+        owner: Option<u128>,
         last_grab: Option<std::time::Instant>,
         /// True while a deferred-release thread is in flight. Prevents
         /// spawning redundant threads during the X11 feedback loop.
@@ -122,7 +122,7 @@ pub mod client {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u64) {
+    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u128) {
         #[cfg(feature = "flutter")]
         if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
             return;
@@ -148,7 +148,7 @@ pub mod client {
                     return;
                 }
 
-                log::info!(
+                log::debug!(
                     "[grab] Run(0x{:x}): prev_owner={}, mode={}",
                     session_id,
                     gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
@@ -165,7 +165,7 @@ pub mod client {
                     // and the X server in a consistent state even if the prior
                     // owner never sent `Wait` (e.g. disconnected or raced).
                     if gs.owner.is_some() {
-                        log::info!("[grab] handoff: disable_grab before re-grab");
+                        log::debug!("[grab] handoff: disable_grab before re-grab");
                         rdev::disable_grab();
                     }
                     rdev::enable_grab();
@@ -214,7 +214,7 @@ pub mod client {
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {
                                     gs.deferred_pending = false;
-                                    log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
+                                    log::debug!("[grab] Wait(0x{:x}): deferred release", session_id);
                                     release_remote_keys(&mode);
                                     KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
                                     rdev::disable_grab();
@@ -237,7 +237,7 @@ pub mod client {
                     }
                 }
 
-                log::info!("[grab] Wait(0x{:x}): releasing grab", session_id);
+                log::debug!("[grab] Wait(0x{:x}): releasing grab", session_id);
 
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
@@ -252,6 +252,7 @@ pub mod client {
 
                 gs.owner = None;
                 gs.last_grab = None;
+                gs.deferred_pending = false;
             }
             GrabState::Exit => {}
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -92,11 +92,14 @@ pub mod client {
     struct GrabOwnerState {
         owner: Option<u64>,
         last_grab: Option<std::time::Instant>,
+        /// True while a deferred-release thread is in flight. Prevents
+        /// spawning redundant threads during the X11 feedback loop.
+        deferred_pending: bool,
     }
 
     impl Default for GrabOwnerState {
         fn default() -> Self {
-            Self { owner: None, last_grab: None }
+            Self { owner: None, last_grab: None, deferred_pending: false }
         }
     }
 
@@ -184,14 +187,46 @@ pub mod client {
                 // feedback loop (grab -> PointerExit -> ungrab -> PointerEnter ->
                 // grab -> ...). Suppress Wait if the grab was acquired recently
                 // by this same session -- it is X11 feedback, not a real leave.
+                // A deferred release is scheduled so that a genuine leave within
+                // the debounce window is not permanently lost.
                 #[cfg(target_os = "linux")]
                 if let Some(t) = gs.last_grab {
                     let elapsed = t.elapsed().as_millis();
                     if elapsed < GRAB_DEBOUNCE_MS {
-                        log::debug!(
-                            "[grab] Wait(0x{:x}): debounced ({}ms < {}ms)",
-                            session_id, elapsed, GRAB_DEBOUNCE_MS,
-                        );
+                        if !gs.deferred_pending {
+                            log::debug!(
+                                "[grab] Wait(0x{:x}): debounced ({}ms < {}ms), scheduling deferred release",
+                                session_id, elapsed, GRAB_DEBOUNCE_MS,
+                            );
+                            gs.deferred_pending = true;
+                            let remaining = (GRAB_DEBOUNCE_MS - elapsed) as u64 + 50;
+                            let snapshot = gs.last_grab;
+                            let mode = keyboard_mode.to_string();
+                            std::thread::spawn(move || {
+                                std::thread::sleep(std::time::Duration::from_millis(remaining));
+                                let mut gs = GRAB_STATE.lock().unwrap();
+                                gs.deferred_pending = false;
+                                // Release only if no new Run has refreshed the grab since.
+                                if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                    log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
+                                    release_remote_keys(&mode);
+                                    KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
+                                    rdev::disable_grab();
+                                    gs.owner = None;
+                                    gs.last_grab = None;
+                                } else {
+                                    log::debug!(
+                                        "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
+                                        session_id,
+                                    );
+                                }
+                            });
+                        } else {
+                            log::debug!(
+                                "[grab] Wait(0x{:x}): debounced, deferred release already pending",
+                                session_id,
+                            );
+                        }
                         return;
                     }
                 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -111,6 +111,37 @@ pub mod client {
     lazy_static::lazy_static! {
         static ref IS_GRAB_STARTED: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
         static ref GRAB_STATE: Arc<Mutex<GrabOwnerState>> = Arc::new(Mutex::new(GrabOwnerState::default()));
+        #[cfg(target_os = "linux")]
+        static ref GRAB_OP_LOCK: Mutex<()> = Mutex::new(());
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_run_grab_if_owner(session_id: u128, disable_first: bool) {
+        let _lock = GRAB_OP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let should_apply = {
+            let gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+            gs.owner == Some(session_id)
+        };
+        if !should_apply {
+            return;
+        }
+        if disable_first {
+            log::debug!("[grab] handoff: disable_grab before re-grab");
+            rdev::disable_grab();
+        }
+        rdev::enable_grab();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn disable_grab_if_released() {
+        let _lock = GRAB_OP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let should_disable = {
+            let gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+            gs.owner.is_none() && gs.last_grab.is_none()
+        };
+        if should_disable {
+            rdev::disable_grab();
+        }
     }
 
     pub fn start_grab_loop() {
@@ -130,6 +161,11 @@ pub mod client {
         }
         // Serialize transitions so a stale `Wait` from a previous owner cannot
         // clobber a fresh `Run` from a different session window.
+        let mut release_owner_after_unlock = None;
+        #[cfg(target_os = "linux")]
+        let mut run_grab_after_unlock = None;
+        #[cfg(target_os = "linux")]
+        let mut disable_after_unlock = false;
         let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
         match state {
             GrabState::Ready => {}
@@ -145,37 +181,40 @@ pub mod client {
                     // Reset so the next Wait can spawn a fresh deferred-release
                     // timer with an up-to-date snapshot of last_grab.
                     gs.deferred_pending = false;
-                    log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
+                    log::debug!(
+                        "[grab] Run(0x{:x}): already owner, refresh debounce",
+                        session_id
+                    );
                     return;
                 }
 
                 log::debug!(
                     "[grab] Run(0x{:x}): prev_owner={}, mode={}",
                     session_id,
-                    gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    gs.owner
+                        .map_or("none".to_string(), |id| format!("0x{:x}", id)),
                     keyboard_mode,
                 );
+
+                if let Some(owner) = gs.owner {
+                    release_owner_after_unlock = Some((owner, take_remote_keys()));
+                }
 
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
                 KEYBOARD_HOOKED.store(true, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
-                {
-                    // On handoff, explicitly release any prior owner's X11 grab
-                    // before taking our own. This keeps the rdev control thread
-                    // and the X server in a consistent state even if the prior
-                    // owner never sent `Wait` (e.g. disconnected or raced).
-                    if gs.owner.is_some() {
-                        log::debug!("[grab] handoff: disable_grab before re-grab");
-                        rdev::disable_grab();
-                    }
-                    rdev::enable_grab();
-                }
+                let had_owner = gs.owner.is_some();
                 gs.owner = Some(session_id);
-                gs.last_grab = Some(std::time::Instant::now());
+                let last_grab = std::time::Instant::now();
+                gs.last_grab = Some(last_grab);
                 // Invalidate any in-flight deferred release from the previous
                 // owner so it cannot suppress a fresh timer for the new owner.
                 gs.deferred_pending = false;
+                #[cfg(target_os = "linux")]
+                {
+                    run_grab_after_unlock = Some(had_owner);
+                }
             }
             GrabState::Wait => {
                 // Drop stale `Wait` events that do not correspond to the
@@ -185,7 +224,8 @@ pub mod client {
                     log::debug!(
                         "[grab] Wait(0x{:x}): ignored, owner={}",
                         session_id,
-                        gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                        gs.owner
+                            .map_or("none".to_string(), |id| format!("0x{:x}", id)),
                     );
                     return;
                 }
@@ -211,21 +251,32 @@ pub mod client {
                             let mode = keyboard_mode.to_string();
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
-                                let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
-                                // Release only if no new Run has refreshed the grab since.
-                                if gs.owner == Some(session_id) && gs.last_grab == snapshot {
-                                    gs.deferred_pending = false;
-                                    log::debug!("[grab] Wait(0x{:x}): deferred release", session_id);
-                                    release_remote_keys(&mode);
-                                    KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
-                                    rdev::disable_grab();
-                                    gs.owner = None;
-                                    gs.last_grab = None;
-                                } else {
-                                    log::debug!(
-                                        "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
-                                        session_id,
-                                    );
+                                let release_keys = {
+                                    let mut gs =
+                                        GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+                                    // Release only if no new Run has refreshed the grab since.
+                                    if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                        let to_release = take_remote_keys();
+                                        gs.deferred_pending = false;
+                                        log::debug!(
+                                            "[grab] Wait(0x{:x}): deferred release",
+                                            session_id
+                                        );
+                                        KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
+                                        gs.owner = None;
+                                        gs.last_grab = None;
+                                        Some(to_release)
+                                    } else {
+                                        log::debug!(
+                                            "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
+                                            session_id,
+                                        );
+                                        None
+                                    }
+                                };
+                                if let Some(to_release) = release_keys {
+                                    disable_grab_if_released();
+                                    release_remote_keys_for_owner(&mode, session_id, to_release);
                                 }
                             });
                         } else {
@@ -243,19 +294,32 @@ pub mod client {
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
 
-                release_remote_keys(keyboard_mode);
-
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
                 KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
-
-                #[cfg(target_os = "linux")]
-                rdev::disable_grab();
 
                 gs.owner = None;
                 gs.last_grab = None;
                 gs.deferred_pending = false;
+                release_owner_after_unlock = Some((session_id, take_remote_keys()));
+                #[cfg(target_os = "linux")]
+                {
+                    disable_after_unlock = true;
+                }
             }
             GrabState::Exit => {}
+        }
+        drop(gs);
+        #[cfg(target_os = "linux")]
+        {
+            if disable_after_unlock {
+                disable_grab_if_released();
+            }
+            if let Some(disable_first) = run_grab_after_unlock {
+                apply_run_grab_if_owner(session_id, disable_first);
+            }
+        }
+        if let Some((owner, to_release)) = release_owner_after_unlock {
+            release_remote_keys_for_owner(keyboard_mode, owner, to_release);
         }
     }
 
@@ -282,6 +346,22 @@ pub mod client {
         }
         let peer = session.peer_platform().to_lowercase();
         for key_event in event_to_key_events(peer, &event, keyboard_mode, lock_modes) {
+            session.send_key_event(&key_event);
+        }
+    }
+
+    #[cfg_attr(not(feature = "flutter"), allow(dead_code))]
+    pub fn send_event_with_session<T: InvokeUiSession>(
+        keyboard_mode: &str,
+        event: &Event,
+        session: &Session<T>,
+    ) {
+        let keyboard_mode = get_keyboard_mode_enum(keyboard_mode);
+        let peer = session.peer_platform().to_lowercase();
+        update_modifiers_state(event);
+        for key_event in
+            event_to_key_events_without_release_tracking(peer, event, keyboard_mode, None)
+        {
             session.send_key_event(&key_event);
         }
     }
@@ -472,7 +552,6 @@ fn notify_exit_relative_mouse_mode() {
     flutter::push_session_event(&session_id, "exit_relative_mouse_mode", vec![]);
 }
 
-
 /// Handle relative mouse mode shortcuts in the rdev grab loop.
 /// Returns true if the event should be blocked from being sent to the peer.
 #[cfg(feature = "flutter")]
@@ -519,10 +598,8 @@ fn should_block_relative_mouse_shortcut(key: Key, is_press: bool) -> bool {
     #[cfg(target_os = "macos")]
     let is_tracked_key = key == Key::KeyG;
     #[cfg(not(target_os = "macos"))]
-    let is_tracked_key = key == Key::ControlLeft
-        || key == Key::ControlRight
-        || key == Key::Alt
-        || key == Key::AltGr;
+    let is_tracked_key =
+        key == Key::ControlLeft || key == Key::ControlRight || key == Key::Alt || key == Key::AltGr;
 
     // Block key up if key down was blocked (to avoid orphan key up event on remote).
     // This must be checked before clearing the flag below.
@@ -671,22 +748,91 @@ pub fn is_long_press(event: &Event) -> bool {
     return false;
 }
 
-pub fn release_remote_keys(keyboard_mode: &str) {
-    // todo!: client quit suddenly, how to release keys?
-    let to_release = TO_RELEASE.lock().unwrap().clone();
-    TO_RELEASE.lock().unwrap().clear();
+fn take_remote_keys() -> HashMap<Key, Event> {
+    let mut to_release = TO_RELEASE.lock().unwrap_or_else(|e| e.into_inner());
+    std::mem::take(&mut *to_release)
+}
+
+fn release_remote_keys_for_events<F>(
+    keyboard_mode: &str,
+    to_release: HashMap<Key, Event>,
+    mut process_event: F,
+) where
+    F: FnMut(&str, &Event),
+{
     for (key, mut event) in to_release.into_iter() {
         event.event_type = EventType::KeyRelease(key);
-        client::process_event(keyboard_mode, &event, None);
+        process_event(keyboard_mode, &event);
         // If Alt or AltGr is pressed, we need to send another key stoke to release it.
         // Because the controlled side may hold the alt state, if local window is switched by [Alt + Tab].
         if key == Key::Alt || key == Key::AltGr {
             event.event_type = EventType::KeyPress(key);
-            client::process_event(keyboard_mode, &event, None);
+            process_event(keyboard_mode, &event);
             event.event_type = EventType::KeyRelease(key);
-            client::process_event(keyboard_mode, &event, None);
+            process_event(keyboard_mode, &event);
         }
     }
+}
+
+#[allow(dead_code)]
+pub fn release_remote_keys(keyboard_mode: &str) {
+    // todo!: client quit suddenly, how to release keys?
+    release_remote_keys_for_events(keyboard_mode, take_remote_keys(), |mode, event| {
+        client::process_event(mode, event, None)
+    });
+}
+
+#[cfg(all(
+    feature = "flutter",
+    not(any(target_os = "android", target_os = "ios"))
+))]
+fn release_remote_keys_for_owner(
+    _keyboard_mode: &str,
+    owner: u128,
+    to_release: HashMap<Key, Event>,
+) {
+    let session_id = hbb_common::SessionID::from_u128(owner);
+    let session = flutter::sessions::get_session_by_session_id(&session_id).or_else(|| {
+        flutter::sessions::get_sessions()
+            .into_iter()
+            .find(|session| {
+                (session
+                    .lc
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .session_id as u128)
+                    == owner
+            })
+    });
+    let Some(session) = session else {
+        let dropped = to_release.len();
+        if dropped > 0 {
+            log::warn!(
+                "[grab] cannot release {} remote keys: owner 0x{:x} not found",
+                dropped,
+                owner
+            );
+        }
+        return;
+    };
+    let owner_keyboard_mode = session.get_keyboard_mode();
+    release_remote_keys_for_events(&owner_keyboard_mode, to_release, |mode, event| {
+        client::send_event_with_session(mode, event, &session)
+    });
+}
+
+#[cfg(not(all(
+    feature = "flutter",
+    not(any(target_os = "android", target_os = "ios"))
+)))]
+fn release_remote_keys_for_owner(
+    keyboard_mode: &str,
+    _owner: u128,
+    to_release: HashMap<Key, Event>,
+) {
+    release_remote_keys_for_events(keyboard_mode, to_release, |mode, event| {
+        client::process_event(mode, event, None)
+    });
 }
 
 pub fn get_keyboard_mode_enum(keyboard_mode: &str) -> KeyboardMode {
@@ -879,7 +1025,6 @@ pub fn event_to_key_events(
 ) -> Vec<KeyEvent> {
     peer.retain(|c| !c.is_whitespace());
 
-    let mut key_event = KeyEvent::new();
     update_modifiers_state(event);
 
     match event.event_type {
@@ -892,6 +1037,18 @@ pub fn event_to_key_events(
         _ => {}
     }
 
+    event_to_key_events_without_release_tracking(peer, event, keyboard_mode, _lock_modes)
+}
+
+fn event_to_key_events_without_release_tracking(
+    mut peer: String,
+    event: &Event,
+    keyboard_mode: KeyboardMode,
+    _lock_modes: Option<i32>,
+) -> Vec<KeyEvent> {
+    peer.retain(|c| !c.is_whitespace());
+
+    let mut key_event = KeyEvent::new();
     key_event.mode = keyboard_mode.into();
 
     let mut key_events = match keyboard_mode {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -870,12 +870,14 @@ impl<T: InvokeUiSession> Session<T> {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn enter(&self, keyboard_mode: String) {
-        keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode);
+        let session_id = self.lc.read().unwrap().session_id;
+        keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode, session_id);
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn leave(&self, keyboard_mode: String) {
-        keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode);
+        let session_id = self.lc.read().unwrap().session_id;
+        keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode, session_id);
     }
 
     // flutter only TODO new input

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -870,13 +870,13 @@ impl<T: InvokeUiSession> Session<T> {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn enter(&self, keyboard_mode: String) {
-        let session_id = self.lc.read().unwrap().session_id;
+        let session_id = self.lc.read().unwrap().session_id as u128;
         keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode, session_id);
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn leave(&self, keyboard_mode: String) {
-        let session_id = self.lc.read().unwrap().session_id;
+        let session_id = self.lc.read().unwrap().session_id as u128;
         keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode, session_id);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved keyboard grab conflicts when the same peer is opened in multiple windows by making grab ownership window-aware.
  * Made keyboard grab/ungrab transitions deterministic to prevent stale sessions from overriding active grabs.
  * Added a Linux debounce and delayed-release path to stabilize remote key release behavior and reduce spurious releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->