### PR TITLE
fix(mobile): lock canvas

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
@@ -10,6 +11,7 @@ import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/input_model.dart';
+import 'package:flutter_hbb/utils/canvas_lock.dart';
 
 import './gestures.dart';
 
@@ -92,6 +94,7 @@ class _RawTouchGestureDetectorRegionState
   int _cacheLongPressPositionTs = 0;
   double _mouseScrollIntegral = 0; // mouse scroll speed controller
   double _scale = 1;
+  bool _canvasLockLoaded = !isMobile;
 
   // Workaround tap down event when two fingers are used to scale(mobile)
   TapDownDetails? _lastTapDownDetails;
@@ -115,6 +118,43 @@ class _RawTouchGestureDetectorRegionState
   InputModel get inputModel => widget.inputModel;
   bool get handleTouch => (isDesktop || isWebDesktop) || ffiModel.touchMode;
   SessionID get sessionId => ffi.sessionId;
+  String get sessionKey => sessionId.toString();
+
+  @override
+  void initState() {
+    super.initState();
+    if (isMobile && !widget.isCamera) {
+      _canvasLockLoaded = false;
+      unawaited(_loadCachedCanvasLock().then((_) {
+        if (!mounted) return;
+        _canvasLockLoaded = true;
+      }).catchError((Object e, StackTrace s) {
+        debugPrint('Failed to load canvas lock option: $e');
+        debugPrintStack(stackTrace: s);
+        if (!mounted) return;
+        _canvasLockLoaded = true;
+      }));
+    }
+  }
+
+  @override
+  void dispose() {
+    if (isMobile && !widget.isCamera) {
+      clearCachedCanvasLockValue(sessionKey);
+    }
+    super.dispose();
+  }
+
+  Future<void> _loadCachedCanvasLock() async {
+    final revision = canvasLockRevision(sessionKey);
+    final lockValue = await bind.sessionGetFlutterOption(
+        sessionId: sessionId, k: kLockCanvasOptionKey);
+    if (!mounted) {
+      return;
+    }
+    setInitialCachedCanvasLockValue(
+        sessionKey, isCanvasLockEnabled(lockValue), revision);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -485,6 +525,13 @@ class _RawTouchGestureDetectorRegionState
       }
     } else {
       // mobile
+      final isCanvasLocked = cachedCanvasLockValue(sessionKey);
+      if (!widget.isCamera &&
+          (isCanvasLocked ||
+              (!_canvasLockLoaded && !hasCachedCanvasLockValue(sessionKey)))) {
+        _scale = d.scale;
+        return;
+      }
       ffi.canvasModel.updateScale(d.scale / _scale, d.focalPoint);
       _scale = d.scale;
       ffi.canvasModel.panX(d.focalPointDelta.dx);

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -11,6 +11,7 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/widgets/remote_toolbar.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:flutter_hbb/utils/canvas_lock.dart';
 import 'package:flutter_hbb/utils/multi_window_manager.dart';
 import 'package:get/get.dart';
 
@@ -592,13 +593,58 @@ Future<List<TToggleMenu>> toolbarCursor(
 }
 
 Future<List<TToggleMenu>> toolbarDisplayToggle(
-    BuildContext context, String id, FFI ffi) async {
+    BuildContext context, String id, FFI ffi,
+    {bool supportsCanvasLock = true}) async {
   List<TToggleMenu> v = [];
   final ffiModel = ffi.ffiModel;
   final pi = ffiModel.pi;
   final perms = ffiModel.permissions;
   final sessionId = ffi.sessionId;
+  final sessionKey = sessionId.toString();
   final isDefaultConn = ffi.connType == ConnType.defaultConn;
+
+  if (supportsCanvasLock && isMobile && isDefaultConn) {
+    var initialLockValue = cachedCanvasLockValue(sessionKey);
+    final initialRevision = canvasLockRevision(sessionKey);
+    try {
+      final lockValue = await bind.sessionGetFlutterOption(
+          sessionId: sessionId, k: kLockCanvasOptionKey);
+      final resolvedLockValue = isCanvasLockEnabled(lockValue);
+      initialLockValue = resolvedLockValue;
+      if (canvasLockRevision(sessionKey) == initialRevision) {
+        syncCachedCanvasLockValue(sessionKey, resolvedLockValue);
+      }
+    } catch (e, stack) {
+      debugPrint('Failed to read lock canvas option: $e');
+      debugPrintStack(stackTrace: stack);
+    }
+    var committedLockValue = initialLockValue;
+    var lockWriteEpoch = 0;
+    v.add(TToggleMenu(
+        value: initialLockValue,
+        onChanged: (value) async {
+          if (value == null) return;
+          final epoch = ++lockWriteEpoch;
+          final previous = committedLockValue;
+          setCachedCanvasLockValue(sessionKey, value);
+          try {
+            await bind.sessionSetFlutterOption(
+                sessionId: sessionId,
+                k: kLockCanvasOptionKey,
+                v: canvasLockValue(value));
+            if (epoch == lockWriteEpoch) {
+              committedLockValue = value;
+            }
+          } catch (e, stack) {
+            if (epoch == lockWriteEpoch) {
+              setCachedCanvasLockValue(sessionKey, previous);
+            }
+            debugPrint('Failed to persist lock canvas option: $e');
+            debugPrintStack(stackTrace: stack);
+          }
+        },
+        child: Text(translate('Lock canvas'))));
+  }
 
   // show quality monitor
   final option = 'show-quality-monitor';

--- a/flutter/lib/mobile/pages/view_camera_page.dart
+++ b/flutter/lib/mobile/pages/view_camera_page.dart
@@ -630,7 +630,7 @@ void showOptions(
       await toolbarImageQuality(context, id, gFFI);
   List<TRadioMenu<String>> codecRadios = await toolbarCodec(context, id, gFFI);
   List<TToggleMenu> displayToggles =
-      await toolbarDisplayToggle(context, id, gFFI);
+      await toolbarDisplayToggle(context, id, gFFI, supportsCanvasLock: false);
 
   dialogManager.show((setState, close, context) {
     var viewStyle =

--- a/flutter/lib/utils/canvas_lock.dart
+++ b/flutter/lib/utils/canvas_lock.dart
@@ -1,0 +1,43 @@
+const String kLockCanvasOptionKey = 'lock-canvas';
+const String _kCanvasLockEnabledValue = 'Y';
+const String _kCanvasLockDisabledValue = 'N';
+
+final Map<String, bool> _canvasLockCache = {};
+final Map<String, int> _canvasLockRevisions = {};
+
+bool isCanvasLockEnabled(String? value) => value == _kCanvasLockEnabledValue;
+
+String canvasLockValue(bool enabled) =>
+    enabled ? _kCanvasLockEnabledValue : _kCanvasLockDisabledValue;
+
+bool cachedCanvasLockValue(String sessionKey) =>
+    _canvasLockCache[sessionKey] ?? false;
+
+bool hasCachedCanvasLockValue(String sessionKey) =>
+    _canvasLockCache.containsKey(sessionKey);
+
+int canvasLockRevision(String sessionKey) =>
+    _canvasLockRevisions[sessionKey] ?? 0;
+
+void setCachedCanvasLockValue(String sessionKey, bool enabled) {
+  _canvasLockCache[sessionKey] = enabled;
+  _canvasLockRevisions[sessionKey] = canvasLockRevision(sessionKey) + 1;
+}
+
+void syncCachedCanvasLockValue(String sessionKey, bool enabled) {
+  _canvasLockCache[sessionKey] = enabled;
+}
+
+void setInitialCachedCanvasLockValue(
+    String sessionKey, bool enabled, int expectedRevision) {
+  if (canvasLockRevision(sessionKey) != expectedRevision ||
+      _canvasLockCache.containsKey(sessionKey)) {
+    return;
+  }
+  _canvasLockCache[sessionKey] = enabled;
+}
+
+void clearCachedCanvasLockValue(String sessionKey) {
+  _canvasLockCache.remove(sessionKey);
+  _canvasLockRevisions.remove(sessionKey);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile "Lock canvas" toggle in the toolbar to prevent pan/zoom during two-finger scaling; state is cached per session for fast restore. Camera view disables this option.

* **Bug Fixes**
  * Two-finger gesture handling now consults the cached lock state and safely handles async load/save failures to avoid unintended view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->