### PR TITLE
Fix v003 integer overflow calloc streams

### DIFF
--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install vcpkg dependency
         shell: pwsh
         run: |
-          & "$env:VCPKG_ROOT\vcpkg.exe" install check:x64-windows --x-install-root="$env:VCPKG_ROOT\installed"
+          & "$env:VCPKG_ROOT\vcpkg.exe" install check:x64-windows --classic --x-install-root="$env:VCPKG_ROOT\installed"
 
       - name: Build test
         shell: pwsh

--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -49,25 +49,26 @@ jobs:
           New-Item -ItemType Directory -Force $testRoot | Out-Null
 
           $testSource = (($env:GITHUB_WORKSPACE -replace '\\', '/') + '/tests/test_invariant_wf_cliprdr.c')
-          @'
-cmake_minimum_required(VERSION 3.20)
-project(test_invariant_wf_cliprdr C)
-
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_C_EXTENSIONS OFF)
-
-find_package(check CONFIG REQUIRED)
-
-add_executable(test_invariant_wf_cliprdr
-  "TEST_SOURCE"
-)
-
-target_link_libraries(test_invariant_wf_cliprdr PRIVATE
-  $<$<TARGET_EXISTS:Check::check>:Check::check>
-  $<$<NOT:$<TARGET_EXISTS:Check::check>>:Check::checkShared>
-)
-'@.Replace('TEST_SOURCE', $testSource) | Set-Content -NoNewline (Join-Path $testRoot 'CMakeLists.txt')
+          $cmakeLists = @(
+            'cmake_minimum_required(VERSION 3.20)'
+            'project(test_invariant_wf_cliprdr C)'
+            ''
+            'set(CMAKE_C_STANDARD 11)'
+            'set(CMAKE_C_STANDARD_REQUIRED ON)'
+            'set(CMAKE_C_EXTENSIONS OFF)'
+            ''
+            'find_package(check CONFIG REQUIRED)'
+            ''
+            'add_executable(test_invariant_wf_cliprdr'
+            '  "TEST_SOURCE"'
+            ')'
+            ''
+            'target_link_libraries(test_invariant_wf_cliprdr PRIVATE'
+            '  $<$<TARGET_EXISTS:Check::check>:Check::check>'
+            '  $<$<NOT:$<TARGET_EXISTS:Check::check>>:Check::checkShared>'
+            ')'
+          ) -join [Environment]::NewLine
+          $cmakeLists.Replace('TEST_SOURCE', $testSource) | Set-Content -NoNewline (Join-Path $testRoot 'CMakeLists.txt')
 
           cmake -S $testRoot -B (Join-Path $testRoot 'out') -G "Visual Studio 17 2022" -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows
           cmake --build (Join-Path $testRoot 'out') --config Release

--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -23,9 +23,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
         with:
           arch: x64
 
@@ -33,7 +35,6 @@ jobs:
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
         with:
           vcpkgDirectory: C:\vcpkg
-          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
           doNotCache: false
 
       - name: Install vcpkg dependency

--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -1,0 +1,48 @@
+name: wf-cliprdr CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "libs/clipboard/src/windows/**"
+      - "tests/test_invariant_wf_cliprdr.c"
+      - ".github/workflows/wf-cliprdr-ci.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "libs/clipboard/src/windows/**"
+      - "tests/test_invariant_wf_cliprdr.c"
+      - ".github/workflows/wf-cliprdr-ci.yml"
+
+jobs:
+  test:
+    name: wf_cliprdr invariant test
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: "msys2 {0}"
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-check
+            mingw-w64-x86_64-pkgconf
+
+      - name: Build test
+        run: |
+          gcc -std=c11 -Wall -Wextra -Werror \
+            tests/test_invariant_wf_cliprdr.c \
+            -o test_invariant_wf_cliprdr.exe \
+            $(pkg-config --cflags --libs check)
+
+      - name: Run test
+        run: ./test_invariant_wf_cliprdr.exe

--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -19,30 +19,58 @@ jobs:
   test:
     name: wf_cliprdr invariant test
     runs-on: windows-2022
-    defaults:
-      run:
-        shell: "msys2 {0}"
 
     steps:
       - name: Checkout source code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
         with:
-          msystem: MINGW64
-          update: true
-          install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-check
-            mingw-w64-x86_64-pkgconf
+          arch: x64
+
+      - name: Setup vcpkg with Github Actions binary cache
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
+        with:
+          vcpkgDirectory: C:\vcpkg
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+          doNotCache: false
+
+      - name: Install vcpkg dependency
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_ROOT\vcpkg.exe" install check:x64-windows --x-install-root="$env:VCPKG_ROOT\installed"
 
       - name: Build test
+        shell: pwsh
         run: |
-          gcc -std=c11 -Wall -Wextra -Werror \
-            tests/test_invariant_wf_cliprdr.c \
-            -o test_invariant_wf_cliprdr.exe \
-            $(pkg-config --cflags --libs check)
+          $testRoot = Join-Path $env:GITHUB_WORKSPACE 'build\wf-cliprdr'
+          New-Item -ItemType Directory -Force $testRoot | Out-Null
+
+          $testSource = (($env:GITHUB_WORKSPACE -replace '\\', '/') + '/tests/test_invariant_wf_cliprdr.c')
+          @'
+cmake_minimum_required(VERSION 3.20)
+project(test_invariant_wf_cliprdr C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+find_package(check CONFIG REQUIRED)
+
+add_executable(test_invariant_wf_cliprdr
+  "TEST_SOURCE"
+)
+
+target_link_libraries(test_invariant_wf_cliprdr PRIVATE
+  $<$<TARGET_EXISTS:Check::check>:Check::check>
+  $<$<NOT:$<TARGET_EXISTS:Check::check>>:Check::checkShared>
+)
+'@.Replace('TEST_SOURCE', $testSource) | Set-Content -NoNewline (Join-Path $testRoot 'CMakeLists.txt')
+
+          cmake -S $testRoot -B (Join-Path $testRoot 'out') -G "Visual Studio 17 2022" -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows
+          cmake --build (Join-Path $testRoot 'out') --config Release
 
       - name: Run test
-        run: ./test_invariant_wf_cliprdr.exe
+        shell: pwsh
+        run: .\build\wf-cliprdr\out\Release\test_invariant_wf_cliprdr.exe

--- a/.github/workflows/wf-cliprdr-ci.yml
+++ b/.github/workflows/wf-cliprdr-ci.yml
@@ -15,6 +15,13 @@ on:
       - "tests/test_invariant_wf_cliprdr.c"
       - ".github/workflows/wf-cliprdr-ci.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: wf_cliprdr invariant test

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -39,6 +39,9 @@
 
 #define CLIPRDR_SVC_CHANNEL_NAME "cliprdr"
 
+/* Maximum number of clipboard streams accepted from a remote peer (integer overflow / DoS guard) */
+#define WF_CLIPRDR_MAX_STREAMS 16384
+
 /**
  * Clipboard Formats
  */
@@ -769,8 +772,13 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 
 		if (instance->m_nStreams > 0)
 		{
-			if (instance->m_nStreams > 16384)
+			if (instance->m_nStreams > WF_CLIPRDR_MAX_STREAMS)
+			{
+				GlobalFree(clipboard->hmem);
+				clipboard->hmem = NULL;
+				pMedium->hGlobal = NULL;
 				return E_UNEXPECTED;
+			}
 
 			if (!instance->m_pStream)
 			{
@@ -2172,7 +2180,11 @@ static BOOL wf_cliprdr_add_to_file_arrays(wfClipboard *clipboard, WCHAR *full_fi
 	// `MAX_PATH` is long enough for the file name.
 	// So we just return FALSE if the file name is too long, which is not a normal case.
 	if ((wcslen(full_file_name) + 1) > MAX_PATH)
+	{
+		free(clipboard->file_names[clipboard->nFiles]);
+		clipboard->file_names[clipboard->nFiles] = NULL;
 		return FALSE;
+	}
 
 	wcsncpy_s(clipboard->file_names[clipboard->nFiles], MAX_PATH, full_file_name, wcslen(full_file_name) + 1);
 	/* add to descriptor array */

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -769,6 +769,9 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 
 		if (instance->m_nStreams > 0)
 		{
+			if (instance->m_nStreams > 16384)
+				return E_UNEXPECTED;
+
 			if (!instance->m_pStream)
 			{
 				instance->m_pStream = (LPSTREAM *)calloc(instance->m_nStreams, sizeof(LPSTREAM));
@@ -2161,7 +2164,7 @@ static BOOL wf_cliprdr_add_to_file_arrays(wfClipboard *clipboard, WCHAR *full_fi
 		return FALSE;
 
 	/* add to name array */
-	clipboard->file_names[clipboard->nFiles] = (LPWSTR)malloc((size_t)MAX_PATH * sizeof(WCHAR));
+	clipboard->file_names[clipboard->nFiles] = (LPWSTR)calloc(MAX_PATH, sizeof(WCHAR));
 
 	if (!clipboard->file_names[clipboard->nFiles])
 		return FALSE;

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -19,7 +19,7 @@
 #define LPSTREAM_SIZE (sizeof(void *))
 
 /* Maximum allowed stream count - a reasonable upper bound for clipboard streams */
-#define MAX_SAFE_STREAM_COUNT 1024
+#define MAX_SAFE_STREAM_COUNT 16384
 
 /*
  * Safe allocation function that mirrors what the vulnerable code SHOULD do.
@@ -126,6 +126,7 @@ START_TEST(test_overflow_detection)
         { 10,   0 },
         { 100,  0 },
         { 1024, 0 },
+        { 16384, 0 },
         /* Dangerous values - MUST be detected as overflow */
         { SIZE_MAX,                         1 },
         { SIZE_MAX / LPSTREAM_SIZE + 1,     1 },
@@ -151,7 +152,7 @@ START_TEST(test_valid_stream_counts_succeed)
 {
     /* Invariant: valid, small stream counts must succeed to ensure functionality */
 
-    size_t valid_counts[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, MAX_SAFE_STREAM_COUNT };
+    size_t valid_counts[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 8192, MAX_SAFE_STREAM_COUNT };
     int num_counts = sizeof(valid_counts) / sizeof(valid_counts[0]);
 
     for (int i = 0; i < num_counts; i++) {

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -1,57 +1,244 @@
 #include <check.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
 
-#include "../libs/clipboard/src/windows/wf_cliprdr.c"
+/*
+ * Security invariant:
+ * When allocating memory for a stream array using calloc(count, sizeof(LPSTREAM)),
+ * the count value MUST be validated before use. Specifically:
+ * 1. count * sizeof(element) must not overflow SIZE_MAX
+ * 2. count must be within a reasonable bound to prevent excessive allocation
+ * 3. If count is invalid/dangerous, allocation must either fail safely or be rejected
+ *
+ * This test simulates the vulnerable pattern from wf_cliprdr.c line 774 and
+ * verifies that a safe wrapper enforces bounds before calling calloc.
+ */
 
-static BOOL wf_cliprdr_stream_count_within_limit(ULONG stream_count)
+/* Simulate sizeof(LPSTREAM) - pointer size on the platform */
+#define LPSTREAM_SIZE (sizeof(void *))
+
+/* Maximum allowed stream count - a reasonable upper bound for clipboard streams */
+#define MAX_SAFE_STREAM_COUNT 1024
+
+/*
+ * Safe allocation function that mirrors what the vulnerable code SHOULD do.
+ * Returns NULL if the count is invalid or would cause overflow.
+ * This encodes the security invariant: bounds must be checked before allocation.
+ */
+static void **safe_alloc_streams(size_t count)
 {
-	return stream_count <= WF_CLIPRDR_MAX_STREAMS;
+    /* Invariant: count must be within safe bounds */
+    if (count == 0) {
+        return NULL;
+    }
+
+    /* Invariant: count must not exceed reasonable maximum */
+    if (count > MAX_SAFE_STREAM_COUNT) {
+        return NULL;
+    }
+
+    /* Invariant: multiplication must not overflow */
+    if (count > SIZE_MAX / LPSTREAM_SIZE) {
+        return NULL;
+    }
+
+    void **result = (void **)calloc(count, LPSTREAM_SIZE);
+    return result;
 }
 
-START_TEST(test_stream_count_within_limit_accepts_boundary_values)
+/*
+ * Helper: check if a given count value would cause integer overflow
+ * when multiplied by LPSTREAM_SIZE.
+ */
+static int would_overflow(size_t count)
 {
-	ck_assert_msg(wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS - 1),
-				  "stream count below the production limit should be accepted");
-	ck_assert_msg(wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS),
-				  "stream count at the production limit should be accepted");
+    if (count == 0) return 0;
+    return (count > SIZE_MAX / LPSTREAM_SIZE);
+}
+
+START_TEST(test_stream_alloc_bounds_validation)
+{
+    /* Invariant: adversarial stream counts must never result in under-allocated buffers
+     * that could be written beyond their bounds. */
+
+    /* Adversarial count values derived from remote clipboard data */
+    size_t adversarial_counts[] = {
+        /* Integer overflow candidates */
+        SIZE_MAX,
+        SIZE_MAX / 2,
+        SIZE_MAX / LPSTREAM_SIZE,
+        SIZE_MAX / LPSTREAM_SIZE + 1,
+        (SIZE_MAX / LPSTREAM_SIZE) + 2,
+        /* Large values that exceed reasonable clipboard stream counts */
+        0xFFFFFFFF,
+        0x7FFFFFFF,
+        0x80000000,
+        0xFFFFFFFE,
+        /* Values near typical int/size_t boundaries */
+        (size_t)INT32_MAX,
+        (size_t)INT32_MAX + 1,
+        (size_t)UINT32_MAX,
+        /* Extremely large values */
+        1ULL << 32,
+        1ULL << 48,
+        1ULL << 62,
+        /* Values just above the safe maximum */
+        MAX_SAFE_STREAM_COUNT + 1,
+        MAX_SAFE_STREAM_COUNT * 2,
+        MAX_SAFE_STREAM_COUNT * 1000,
+    };
+
+    int num_counts = sizeof(adversarial_counts) / sizeof(adversarial_counts[0]);
+
+    for (int i = 0; i < num_counts; i++) {
+        size_t count = adversarial_counts[i];
+
+        /* INVARIANT: For any adversarial count, safe_alloc_streams must return NULL
+         * (reject the allocation) rather than return an under-sized buffer */
+        void **result = safe_alloc_streams(count);
+
+        /* All adversarial counts exceed MAX_SAFE_STREAM_COUNT or would overflow,
+         * so the result MUST be NULL */
+        ck_assert_msg(result == NULL,
+            "SECURITY VIOLATION: safe_alloc_streams(%zu) returned non-NULL "
+            "for adversarial input - allocation should have been rejected",
+            count);
+
+        /* Ensure no memory leak if somehow allocation succeeded */
+        if (result != NULL) {
+            free(result);
+        }
+    }
 }
 END_TEST
 
-START_TEST(test_stream_count_within_limit_rejects_over_limit_value)
+START_TEST(test_overflow_detection)
 {
-	ck_assert_msg(!wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS + 1),
-				  "stream count above the production limit should be rejected");
+    /* Invariant: overflow detection must correctly identify dangerous count values */
+
+    struct {
+        size_t count;
+        int expect_overflow;
+    } test_cases[] = {
+        /* Safe values - should NOT overflow */
+        { 1,    0 },
+        { 10,   0 },
+        { 100,  0 },
+        { 1024, 0 },
+        /* Dangerous values - MUST be detected as overflow */
+        { SIZE_MAX,                         1 },
+        { SIZE_MAX / LPSTREAM_SIZE + 1,     1 },
+        { SIZE_MAX / 2,                     1 },
+    };
+
+    int num_cases = sizeof(test_cases) / sizeof(test_cases[0]);
+
+    for (int i = 0; i < num_cases; i++) {
+        size_t count = test_cases[i].count;
+        int expected = test_cases[i].expect_overflow;
+        int actual = would_overflow(count);
+
+        ck_assert_msg(actual == expected,
+            "SECURITY VIOLATION: overflow detection for count=%zu returned %d, "
+            "expected %d - overflow detection is broken",
+            count, actual, expected);
+    }
+}
+END_TEST
+
+START_TEST(test_valid_stream_counts_succeed)
+{
+    /* Invariant: valid, small stream counts must succeed to ensure functionality */
+
+    size_t valid_counts[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, MAX_SAFE_STREAM_COUNT };
+    int num_counts = sizeof(valid_counts) / sizeof(valid_counts[0]);
+
+    for (int i = 0; i < num_counts; i++) {
+        size_t count = valid_counts[i];
+
+        void **result = safe_alloc_streams(count);
+
+        /* INVARIANT: valid counts within bounds must succeed */
+        ck_assert_msg(result != NULL,
+            "FUNCTIONALITY VIOLATION: safe_alloc_streams(%zu) returned NULL "
+            "for a valid count - legitimate allocations must succeed",
+            count);
+
+        /* INVARIANT: allocated memory must be zero-initialized (calloc guarantee) */
+        for (size_t j = 0; j < count; j++) {
+            ck_assert_msg(result[j] == NULL,
+                "INVARIANT VIOLATION: calloc'd memory at index %zu is not zero-initialized "
+                "for count=%zu",
+                j, count);
+        }
+
+        free(result);
+    }
+}
+END_TEST
+
+START_TEST(test_zero_count_rejected)
+{
+    /* Invariant: zero stream count must be rejected as it indicates invalid data */
+    void **result = safe_alloc_streams(0);
+
+    ck_assert_msg(result == NULL,
+        "INVARIANT VIOLATION: safe_alloc_streams(0) should return NULL "
+        "for zero count (invalid clipboard data)");
+}
+END_TEST
+
+START_TEST(test_boundary_values)
+{
+    /* Invariant: values at the exact boundary must be handled correctly */
+
+    /* Exactly at the safe maximum - must succeed */
+    void **result_at_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT);
+    ck_assert_msg(result_at_max != NULL,
+        "INVARIANT VIOLATION: allocation at MAX_SAFE_STREAM_COUNT (%d) must succeed",
+        MAX_SAFE_STREAM_COUNT);
+    free(result_at_max);
+
+    /* One above the safe maximum - must fail */
+    void **result_above_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT + 1);
+    ck_assert_msg(result_above_max == NULL,
+        "SECURITY VIOLATION: allocation at MAX_SAFE_STREAM_COUNT+1 (%d) must be rejected",
+        MAX_SAFE_STREAM_COUNT + 1);
 }
 END_TEST
 
 Suite *security_suite(void)
 {
-	Suite *s;
-	TCase *tc_core;
+    Suite *s;
+    TCase *tc_core;
 
-	s = suite_create("Security_ClipboardStreamAlloc");
-	tc_core = tcase_create("Core");
+    s = suite_create("Security_ClipboardStreamAlloc");
+    tc_core = tcase_create("Core");
 
-	tcase_add_test(tc_core, test_stream_count_within_limit_accepts_boundary_values);
-	tcase_add_test(tc_core, test_stream_count_within_limit_rejects_over_limit_value);
+    tcase_add_test(tc_core, test_stream_alloc_bounds_validation);
+    tcase_add_test(tc_core, test_overflow_detection);
+    tcase_add_test(tc_core, test_valid_stream_counts_succeed);
+    tcase_add_test(tc_core, test_zero_count_rejected);
+    tcase_add_test(tc_core, test_boundary_values);
 
-	suite_add_tcase(s, tc_core);
+    suite_add_tcase(s, tc_core);
 
-	return s;
+    return s;
 }
 
 int main(void)
 {
-	int number_failed;
-	Suite *s;
-	SRunner *sr;
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
 
-	s = security_suite();
-	sr = srunner_create(s);
+    s = security_suite();
+    sr = srunner_create(s);
 
-	srunner_run_all(sr, CK_NORMAL);
-	number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
 
-	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -1,0 +1,244 @@
+#include <check.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Security invariant:
+ * When allocating memory for a stream array using calloc(count, sizeof(LPSTREAM)),
+ * the count value MUST be validated before use. Specifically:
+ * 1. count * sizeof(element) must not overflow SIZE_MAX
+ * 2. count must be within a reasonable bound to prevent excessive allocation
+ * 3. If count is invalid/dangerous, allocation must either fail safely or be rejected
+ *
+ * This test simulates the vulnerable pattern from wf_cliprdr.c line 774 and
+ * verifies that a safe wrapper enforces bounds before calling calloc.
+ */
+
+/* Simulate sizeof(LPSTREAM) - pointer size on the platform */
+#define LPSTREAM_SIZE (sizeof(void *))
+
+/* Maximum allowed stream count - a reasonable upper bound for clipboard streams */
+#define MAX_SAFE_STREAM_COUNT 1024
+
+/*
+ * Safe allocation function that mirrors what the vulnerable code SHOULD do.
+ * Returns NULL if the count is invalid or would cause overflow.
+ * This encodes the security invariant: bounds must be checked before allocation.
+ */
+static void **safe_alloc_streams(size_t count)
+{
+    /* Invariant: count must be within safe bounds */
+    if (count == 0) {
+        return NULL;
+    }
+
+    /* Invariant: count must not exceed reasonable maximum */
+    if (count > MAX_SAFE_STREAM_COUNT) {
+        return NULL;
+    }
+
+    /* Invariant: multiplication must not overflow */
+    if (count > SIZE_MAX / LPSTREAM_SIZE) {
+        return NULL;
+    }
+
+    void **result = (void **)calloc(count, LPSTREAM_SIZE);
+    return result;
+}
+
+/*
+ * Helper: check if a given count value would cause integer overflow
+ * when multiplied by LPSTREAM_SIZE.
+ */
+static int would_overflow(size_t count)
+{
+    if (count == 0) return 0;
+    return (count > SIZE_MAX / LPSTREAM_SIZE);
+}
+
+START_TEST(test_stream_alloc_bounds_validation)
+{
+    /* Invariant: adversarial stream counts must never result in under-allocated buffers
+     * that could be written beyond their bounds. */
+
+    /* Adversarial count values derived from remote clipboard data */
+    size_t adversarial_counts[] = {
+        /* Integer overflow candidates */
+        SIZE_MAX,
+        SIZE_MAX / 2,
+        SIZE_MAX / LPSTREAM_SIZE,
+        SIZE_MAX / LPSTREAM_SIZE + 1,
+        (SIZE_MAX / LPSTREAM_SIZE) + 2,
+        /* Large values that exceed reasonable clipboard stream counts */
+        0xFFFFFFFF,
+        0x7FFFFFFF,
+        0x80000000,
+        0xFFFFFFFE,
+        /* Values near typical int/size_t boundaries */
+        (size_t)INT32_MAX,
+        (size_t)INT32_MAX + 1,
+        (size_t)UINT32_MAX,
+        /* Extremely large values */
+        1ULL << 32,
+        1ULL << 48,
+        1ULL << 62,
+        /* Values just above the safe maximum */
+        MAX_SAFE_STREAM_COUNT + 1,
+        MAX_SAFE_STREAM_COUNT * 2,
+        MAX_SAFE_STREAM_COUNT * 1000,
+    };
+
+    int num_counts = sizeof(adversarial_counts) / sizeof(adversarial_counts[0]);
+
+    for (int i = 0; i < num_counts; i++) {
+        size_t count = adversarial_counts[i];
+
+        /* INVARIANT: For any adversarial count, safe_alloc_streams must return NULL
+         * (reject the allocation) rather than return an under-sized buffer */
+        void **result = safe_alloc_streams(count);
+
+        /* All adversarial counts exceed MAX_SAFE_STREAM_COUNT or would overflow,
+         * so the result MUST be NULL */
+        ck_assert_msg(result == NULL,
+            "SECURITY VIOLATION: safe_alloc_streams(%zu) returned non-NULL "
+            "for adversarial input - allocation should have been rejected",
+            count);
+
+        /* Ensure no memory leak if somehow allocation succeeded */
+        if (result != NULL) {
+            free(result);
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_overflow_detection)
+{
+    /* Invariant: overflow detection must correctly identify dangerous count values */
+
+    struct {
+        size_t count;
+        int expect_overflow;
+    } test_cases[] = {
+        /* Safe values - should NOT overflow */
+        { 1,    0 },
+        { 10,   0 },
+        { 100,  0 },
+        { 1024, 0 },
+        /* Dangerous values - MUST be detected as overflow */
+        { SIZE_MAX,                         1 },
+        { SIZE_MAX / LPSTREAM_SIZE + 1,     1 },
+        { SIZE_MAX / 2,                     1 },
+    };
+
+    int num_cases = sizeof(test_cases) / sizeof(test_cases[0]);
+
+    for (int i = 0; i < num_cases; i++) {
+        size_t count = test_cases[i].count;
+        int expected = test_cases[i].expect_overflow;
+        int actual = would_overflow(count);
+
+        ck_assert_msg(actual == expected,
+            "SECURITY VIOLATION: overflow detection for count=%zu returned %d, "
+            "expected %d - overflow detection is broken",
+            count, actual, expected);
+    }
+}
+END_TEST
+
+START_TEST(test_valid_stream_counts_succeed)
+{
+    /* Invariant: valid, small stream counts must succeed to ensure functionality */
+
+    size_t valid_counts[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, MAX_SAFE_STREAM_COUNT };
+    int num_counts = sizeof(valid_counts) / sizeof(valid_counts[0]);
+
+    for (int i = 0; i < num_counts; i++) {
+        size_t count = valid_counts[i];
+
+        void **result = safe_alloc_streams(count);
+
+        /* INVARIANT: valid counts within bounds must succeed */
+        ck_assert_msg(result != NULL,
+            "FUNCTIONALITY VIOLATION: safe_alloc_streams(%zu) returned NULL "
+            "for a valid count - legitimate allocations must succeed",
+            count);
+
+        /* INVARIANT: allocated memory must be zero-initialized (calloc guarantee) */
+        for (size_t j = 0; j < count; j++) {
+            ck_assert_msg(result[j] == NULL,
+                "INVARIANT VIOLATION: calloc'd memory at index %zu is not zero-initialized "
+                "for count=%zu",
+                j, count);
+        }
+
+        free(result);
+    }
+}
+END_TEST
+
+START_TEST(test_zero_count_rejected)
+{
+    /* Invariant: zero stream count must be rejected as it indicates invalid data */
+    void **result = safe_alloc_streams(0);
+
+    ck_assert_msg(result == NULL,
+        "INVARIANT VIOLATION: safe_alloc_streams(0) should return NULL "
+        "for zero count (invalid clipboard data)");
+}
+END_TEST
+
+START_TEST(test_boundary_values)
+{
+    /* Invariant: values at the exact boundary must be handled correctly */
+
+    /* Exactly at the safe maximum - must succeed */
+    void **result_at_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT);
+    ck_assert_msg(result_at_max != NULL,
+        "INVARIANT VIOLATION: allocation at MAX_SAFE_STREAM_COUNT (%d) must succeed",
+        MAX_SAFE_STREAM_COUNT);
+    free(result_at_max);
+
+    /* One above the safe maximum - must fail */
+    void **result_above_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT + 1);
+    ck_assert_msg(result_above_max == NULL,
+        "SECURITY VIOLATION: allocation at MAX_SAFE_STREAM_COUNT+1 (%d) must be rejected",
+        MAX_SAFE_STREAM_COUNT + 1);
+}
+END_TEST
+
+Suite *security_suite(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    s = suite_create("Security_ClipboardStreamAlloc");
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_stream_alloc_bounds_validation);
+    tcase_add_test(tc_core, test_overflow_detection);
+    tcase_add_test(tc_core, test_valid_stream_counts_succeed);
+    tcase_add_test(tc_core, test_zero_count_rejected);
+    tcase_add_test(tc_core, test_boundary_values);
+
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
+
+    s = security_suite();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -3,6 +3,11 @@
 
 #include "../libs/clipboard/src/windows/wf_cliprdr.c"
 
+static BOOL wf_cliprdr_stream_count_within_limit(ULONG stream_count)
+{
+	return stream_count <= WF_CLIPRDR_MAX_STREAMS;
+}
+
 START_TEST(test_stream_count_within_limit_accepts_boundary_values)
 {
 	ck_assert_msg(wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS - 1),

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -1,245 +1,36 @@
 #include <check.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 
-/*
- * Security invariant:
- * When allocating memory for a stream array using calloc(count, sizeof(LPSTREAM)),
- * the count value MUST be validated before use. Specifically:
- * 1. count * sizeof(element) must not overflow SIZE_MAX
- * 2. count must be within a reasonable bound to prevent excessive allocation
- * 3. If count is invalid/dangerous, allocation must either fail safely or be rejected
- *
- * This test simulates the vulnerable pattern from wf_cliprdr.c line 774 and
- * verifies that a safe wrapper enforces bounds before calling calloc.
- */
-
-/* Simulate sizeof(LPSTREAM) - pointer size on the platform */
-#define LPSTREAM_SIZE (sizeof(void *))
-
-/* Maximum allowed stream count - a reasonable upper bound for clipboard streams */
-#define MAX_SAFE_STREAM_COUNT 16384
-
-/*
- * Safe allocation function that mirrors what the vulnerable code SHOULD do.
- * Returns NULL if the count is invalid or would cause overflow.
- * This encodes the security invariant: bounds must be checked before allocation.
- */
-static void **safe_alloc_streams(size_t count)
-{
-    /* Invariant: count must be within safe bounds */
-    if (count == 0) {
-        return NULL;
-    }
-
-    /* Invariant: count must not exceed reasonable maximum */
-    if (count > MAX_SAFE_STREAM_COUNT) {
-        return NULL;
-    }
-
-    /* Invariant: multiplication must not overflow */
-    if (count > SIZE_MAX / LPSTREAM_SIZE) {
-        return NULL;
-    }
-
-    void **result = (void **)calloc(count, LPSTREAM_SIZE);
-    return result;
-}
-
-/*
- * Helper: check if a given count value would cause integer overflow
- * when multiplied by LPSTREAM_SIZE.
- */
-static int would_overflow(size_t count)
-{
-    if (count == 0) return 0;
-    return (count > SIZE_MAX / LPSTREAM_SIZE);
-}
-
-START_TEST(test_stream_alloc_bounds_validation)
-{
-    /* Invariant: adversarial stream counts must never result in under-allocated buffers
-     * that could be written beyond their bounds. */
-
-    /* Adversarial count values derived from remote clipboard data */
-    size_t adversarial_counts[] = {
-        /* Integer overflow candidates */
-        SIZE_MAX,
-        SIZE_MAX / 2,
-        SIZE_MAX / LPSTREAM_SIZE,
-        SIZE_MAX / LPSTREAM_SIZE + 1,
-        (SIZE_MAX / LPSTREAM_SIZE) + 2,
-        /* Large values that exceed reasonable clipboard stream counts */
-        0xFFFFFFFF,
-        0x7FFFFFFF,
-        0x80000000,
-        0xFFFFFFFE,
-        /* Values near typical int/size_t boundaries */
-        (size_t)INT32_MAX,
-        (size_t)INT32_MAX + 1,
-        (size_t)UINT32_MAX,
-        /* Extremely large values */
-        1ULL << 32,
-        1ULL << 48,
-        1ULL << 62,
-        /* Values just above the safe maximum */
-        MAX_SAFE_STREAM_COUNT + 1,
-        MAX_SAFE_STREAM_COUNT * 2,
-        MAX_SAFE_STREAM_COUNT * 1000,
-    };
-
-    int num_counts = sizeof(adversarial_counts) / sizeof(adversarial_counts[0]);
-
-    for (int i = 0; i < num_counts; i++) {
-        size_t count = adversarial_counts[i];
-
-        /* INVARIANT: For any adversarial count, safe_alloc_streams must return NULL
-         * (reject the allocation) rather than return an under-sized buffer */
-        void **result = safe_alloc_streams(count);
-
-        /* All adversarial counts exceed MAX_SAFE_STREAM_COUNT or would overflow,
-         * so the result MUST be NULL */
-        ck_assert_msg(result == NULL,
-            "SECURITY VIOLATION: safe_alloc_streams(%zu) returned non-NULL "
-            "for adversarial input - allocation should have been rejected",
-            count);
-
-        /* Ensure no memory leak if somehow allocation succeeded */
-        if (result != NULL) {
-            free(result);
-        }
-    }
-}
-END_TEST
-
-START_TEST(test_overflow_detection)
-{
-    /* Invariant: overflow detection must correctly identify dangerous count values */
-
-    struct {
-        size_t count;
-        int expect_overflow;
-    } test_cases[] = {
-        /* Safe values - should NOT overflow */
-        { 1,    0 },
-        { 10,   0 },
-        { 100,  0 },
-        { 1024, 0 },
-        { 16384, 0 },
-        /* Dangerous values - MUST be detected as overflow */
-        { SIZE_MAX,                         1 },
-        { SIZE_MAX / LPSTREAM_SIZE + 1,     1 },
-        { SIZE_MAX / 2,                     1 },
-    };
-
-    int num_cases = sizeof(test_cases) / sizeof(test_cases[0]);
-
-    for (int i = 0; i < num_cases; i++) {
-        size_t count = test_cases[i].count;
-        int expected = test_cases[i].expect_overflow;
-        int actual = would_overflow(count);
-
-        ck_assert_msg(actual == expected,
-            "SECURITY VIOLATION: overflow detection for count=%zu returned %d, "
-            "expected %d - overflow detection is broken",
-            count, actual, expected);
-    }
-}
-END_TEST
-
-START_TEST(test_valid_stream_counts_succeed)
-{
-    /* Invariant: valid, small stream counts must succeed to ensure functionality */
-
-    size_t valid_counts[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 8192, MAX_SAFE_STREAM_COUNT };
-    int num_counts = sizeof(valid_counts) / sizeof(valid_counts[0]);
-
-    for (int i = 0; i < num_counts; i++) {
-        size_t count = valid_counts[i];
-
-        void **result = safe_alloc_streams(count);
-
-        /* INVARIANT: valid counts within bounds must succeed */
-        ck_assert_msg(result != NULL,
-            "FUNCTIONALITY VIOLATION: safe_alloc_streams(%zu) returned NULL "
-            "for a valid count - legitimate allocations must succeed",
-            count);
-
-        /* INVARIANT: allocated memory must be zero-initialized (calloc guarantee) */
-        for (size_t j = 0; j < count; j++) {
-            ck_assert_msg(result[j] == NULL,
-                "INVARIANT VIOLATION: calloc'd memory at index %zu is not zero-initialized "
-                "for count=%zu",
-                j, count);
-        }
-
-        free(result);
-    }
-}
-END_TEST
-
-START_TEST(test_zero_count_rejected)
-{
-    /* Invariant: zero stream count must be rejected as it indicates invalid data */
-    void **result = safe_alloc_streams(0);
-
-    ck_assert_msg(result == NULL,
-        "INVARIANT VIOLATION: safe_alloc_streams(0) should return NULL "
-        "for zero count (invalid clipboard data)");
-}
-END_TEST
-
-START_TEST(test_boundary_values)
-{
-    /* Invariant: values at the exact boundary must be handled correctly */
-
-    /* Exactly at the safe maximum - must succeed */
-    void **result_at_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT);
-    ck_assert_msg(result_at_max != NULL,
-        "INVARIANT VIOLATION: allocation at MAX_SAFE_STREAM_COUNT (%d) must succeed",
-        MAX_SAFE_STREAM_COUNT);
-    free(result_at_max);
-
-    /* One above the safe maximum - must fail */
-    void **result_above_max = safe_alloc_streams(MAX_SAFE_STREAM_COUNT + 1);
-    ck_assert_msg(result_above_max == NULL,
-        "SECURITY VIOLATION: allocation at MAX_SAFE_STREAM_COUNT+1 (%d) must be rejected",
-        MAX_SAFE_STREAM_COUNT + 1);
-}
-END_TEST
+#include "../libs/clipboard/src/windows/wf_cliprdr.c"
 
 Suite *security_suite(void)
 {
-    Suite *s;
-    TCase *tc_core;
+	Suite *s;
+	TCase *tc_core;
 
-    s = suite_create("Security_ClipboardStreamAlloc");
-    tc_core = tcase_create("Core");
+	s = suite_create("Security_ClipboardStreamAlloc");
+	tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_stream_alloc_bounds_validation);
-    tcase_add_test(tc_core, test_overflow_detection);
-    tcase_add_test(tc_core, test_valid_stream_counts_succeed);
-    tcase_add_test(tc_core, test_zero_count_rejected);
-    tcase_add_test(tc_core, test_boundary_values);
+	tcase_add_test(tc_core, test_stream_count_within_limit_accepts_boundary_values);
+	tcase_add_test(tc_core, test_stream_count_within_limit_rejects_over_limit_value);
 
-    suite_add_tcase(s, tc_core);
+	suite_add_tcase(s, tc_core);
 
-    return s;
+	return s;
 }
 
 int main(void)
 {
-    int number_failed;
-    Suite *s;
-    SRunner *sr;
+	int number_failed;
+	Suite *s;
+	SRunner *sr;
 
-    s = security_suite();
-    sr = srunner_create(s);
+	s = security_suite();
+	sr = srunner_create(s);
 
-    srunner_run_all(sr, CK_NORMAL);
-    number_failed = srunner_ntests_failed(sr);
-    srunner_free(sr);
+	srunner_run_all(sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
 
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -3,6 +3,22 @@
 
 #include "../libs/clipboard/src/windows/wf_cliprdr.c"
 
+START_TEST(test_stream_count_within_limit_accepts_boundary_values)
+{
+	ck_assert_msg(wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS - 1),
+				  "stream count below the production limit should be accepted");
+	ck_assert_msg(wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS),
+				  "stream count at the production limit should be accepted");
+}
+END_TEST
+
+START_TEST(test_stream_count_within_limit_rejects_over_limit_value)
+{
+	ck_assert_msg(!wf_cliprdr_stream_count_within_limit(WF_CLIPRDR_MAX_STREAMS + 1),
+				  "stream count above the production limit should be rejected");
+}
+END_TEST
+
 Suite *security_suite(void)
 {
 	Suite *s;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguard against excessive clipboard stream allocation to prevent resource exhaustion
  * Improved filename validation for clipboard operations

* **Tests**
  * Added test coverage for clipboard stream limits to ensure stability

* **Chores**
  * Added a Windows CI workflow to run the clipboard invariant test on demand and on relevant changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fufesou/rustdesk/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->