### PR TITLE
fix: non-E2EE show dialog

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1185,6 +1185,43 @@ void msgBox(SessionID sessionId, String type, String title, String text,
     VoidCallback? onSubmit,
     int? submitTimeout}) {
   dialogManager.dismissAll();
+  if (type.contains('insecure-connection')) {
+    void closeSession() {
+      dialogManager.dismissAll();
+      closeConnection();
+    }
+
+    void continueSession() {
+      unawaited(
+        bind.sessionSetCommon(
+          sessionId: sessionId,
+          key: 'insecure-connection-confirmed',
+          value: 'Y',
+        ),
+      );
+      dialogManager.dismissAll();
+    }
+
+    dialogManager.show(
+      (setState, close, context) => CustomAlertDialog(
+        title: null,
+        content: SelectionArea(child: msgboxContent(type, title, text)),
+        actions: [
+          dialogButton(
+            'Continue',
+            onPressed: continueSession,
+            isOutline: true,
+          ),
+          dialogButton('Disconnect', onPressed: closeSession),
+        ],
+        onSubmit: closeSession,
+        onCancel: closeSession,
+      ),
+      tag: '$sessionId-$type-$title-$text-$link',
+    );
+    return;
+  }
+
   List<Widget> buttons = [];
   bool hasOk = false;
   submit() {

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1914,6 +1914,15 @@ class RustdeskImpl {
     throw UnimplementedError("sessionHandleScreenshot");
   }
 
+  Future<void> sessionSetCommon(
+      {required UuidValue sessionId, required String key, required String value, dynamic hint}) {
+      js.context.callMethod('setByName', [
+        'common',
+        jsonEncode({'name': key, 'value': value})
+      ]);
+      return Future.value();
+  }
+
   String? sessionGetCommonSync(
       {required UuidValue sessionId,
       required String key,

--- a/src/client.rs
+++ b/src/client.rs
@@ -3815,6 +3815,7 @@ pub enum Data {
     ElevateWithLogon(String, String),
     NewVoiceCall,
     CloseVoiceCall,
+    ContinueInsecureConnection,
     ResetDecoder(Option<usize>),
     RenameFile((i32, String, String, bool)),
     TakeScreenshot((i32, String)),

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -14,6 +14,7 @@ use crate::{
 // Empirical no-data window before exposing the restart reconnect state to the UI.
 // Restart msgbox text is kept as a legacy UI fallback; Flutter handles the type as a control event.
 const RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT: Duration = Duration::from_secs(5);
+const KCP_CLOSE_REASON_FLUSH_DELAY: Duration = Duration::from_millis(30);
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::{clipboard::try_empty_clipboard_files, clipboard_file::unix_file_clip};
 #[cfg(any(
@@ -183,8 +184,17 @@ impl<T: InvokeUiSession> Remote<T> {
                     .lock()
                     .unwrap()
                     .set_connected();
+                let is_secured = peer.is_secured();
                 self.handler
-                    .set_connection_type(peer.is_secured(), direct, stream_type); // flutter -> connection_ready
+                    .set_connection_type(is_secured, direct, stream_type); // flutter -> connection_ready
+                if !is_secured && !self.confirm_insecure_connection().await {
+                    self.send_close_reason(&mut peer, "").await;
+                    if kcp.is_some() {
+                        tokio::time::sleep(KCP_CLOSE_REASON_FLUSH_DELAY).await;
+                    }
+                    self.handle_disconnected(round);
+                    return;
+                }
                 self.handler.update_direct(Some(direct));
                 if conn_type == ConnType::DEFAULT_CONN || conn_type == ConnType::VIEW_CAMERA {
                     self.handler
@@ -338,13 +348,17 @@ impl<T: InvokeUiSession> Remote<T> {
                     self.send_close_reason(&mut peer, "kcp").await;
                     // KCP does not send messages immediately, so wait to ensure the last message is sent.
                     // 1ms works in my test, but 30ms is more reliable.
-                    tokio::time::sleep(Duration::from_millis(30)).await;
+                    tokio::time::sleep(KCP_CLOSE_REASON_FLUSH_DELAY).await;
                 }
             }
             Err(err) => {
                 self.handler.on_establish_connection_error(err.to_string());
             }
         }
+        self.handle_disconnected(round);
+    }
+
+    fn handle_disconnected(&self, round: u32) {
         // set_disconnected_ok is used to check if new connection round is started.
         let _set_disconnected_ok = self
             .handler
@@ -364,6 +378,23 @@ impl<T: InvokeUiSession> Remote<T> {
             // unmounted. Keep this async path for other file-clipboard platforms.
             crate::clipboard::try_empty_clipboard_files(ClipboardSide::Client, self.client_conn_id);
         }
+    }
+
+    async fn confirm_insecure_connection(&mut self) -> bool {
+        self.handler.msgbox(
+            "insecure-connection-nocancel-hasclose",
+            "Insecure Connection",
+            "conn-e2ee-unavailable-tip",
+            "",
+        );
+        while let Some(data) = self.receiver.recv().await {
+            match data {
+                Data::ContinueInsecureConnection => return true,
+                Data::Close => return false,
+                _ => {}
+            }
+        }
+        false
     }
 
     #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -102,6 +102,10 @@ impl ParsedPeerInfo {
     }
 }
 
+fn is_direct_ip_access(peer: &str) -> bool {
+    hbb_common::is_ip_str(peer) || hbb_common::is_domain_port_str(peer)
+}
+
 impl<T: InvokeUiSession> Remote<T> {
     pub fn new(
         handler: Session<T>,
@@ -187,7 +191,10 @@ impl<T: InvokeUiSession> Remote<T> {
                 let is_secured = peer.is_secured();
                 self.handler
                     .set_connection_type(is_secured, direct, stream_type); // flutter -> connection_ready
-                if !is_secured && !self.confirm_insecure_connection().await {
+                if !is_secured
+                    && !is_direct_ip_access(&self.handler.get_id())
+                    && !self.confirm_insecure_connection().await
+                {
                     self.send_close_reason(&mut peer, "").await;
                     if kcp.is_some() {
                         tokio::time::sleep(KCP_CLOSE_REASON_FLUSH_DELAY).await;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -3020,6 +3020,17 @@ pub fn main_set_common(_key: String, _value: String) {
     }
 }
 
+pub fn session_set_common(session_id: SessionID, key: String, value: String) {
+    if let Some(s) = sessions::get_session_by_session_id(&session_id) {
+        if key == crate::ui_session_interface::INSECURE_CONNECTION_CONFIRM_OPTION
+            && value == "Y"
+        {
+            s.continue_insecure_connection();
+            return;
+        }
+    }
+}
+
 pub fn session_get_common_sync(
     session_id: SessionID,
     key: String,

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "اتصال الوسيط"),
         ("Secure Connection", "اتصال آمن"),
         ("Insecure Connection", "اتصال غير آمن"),
+        ("Continue", ""),
         ("Scale original", "المقياس الأصلي"),
         ("Scale adaptive", "مقياس التكيف"),
         ("General", "عام"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "الإظهار على شريط الأدوات المُصغّر"),
         ("All monitors", "جميع الشاشات"),
         ("#{} monitor", "الشاشة رقم {}"),
+        ("conn-e2ee-unavailable-tip", "تعذر التحقق من التشفير من طرف إلى طرف لهذه الجلسة.\nقد يكون خادم RustDesk معدلا أو غير موثوق به أو ضارا.\nهل ما زلت تريد المتابعة؟"),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Рэтрансляванае падключэнне"),
         ("Secure Connection", "Бяспечнае падключэнне"),
         ("Insecure Connection", "Нябяспечнае падключэнне"),
+        ("Continue", ""),
         ("Scale original", "Арыгінальны маштаб"),
         ("Scale adaptive", "Адаптыўны маштаб"),
         ("General", "Агульныя"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Паказваць на згорнутай панэлі інструментаў"),
         ("All monitors", "Усе манітори"),
         ("#{} monitor", "Манітор {}"),
+        ("conn-e2ee-unavailable-tip", "Не ўдалося праверыць скразное шыфраванне для гэтага сеанса.\nСервер RustDesk можа быць зменены, ненадзейны або шкоднасны.\nВы ўсё яшчэ хочаце працягнуць?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Релейна връзка"),
         ("Secure Connection", "Сигурна връзка"),
         ("Insecure Connection", "Несигурна връзка"),
+        ("Continue", ""),
         ("Scale original", "Оригинален мащаб"),
         ("Scale adaptive", "Приспособимо мащабиране"),
         ("General", "Основен"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показване в минимизираната лента с инструменти"),
         ("All monitors", "Всички монитори"),
         ("#{} monitor", "Монитор {}"),
+        ("conn-e2ee-unavailable-tip", "Шифроването от край до край не може да бъде проверено за тази сесия.\nСървърът на RustDesk може да е модифициран, ненадежден или злонамерен.\nВсе още ли искате да продължите?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Connexió amb repetidor"),
         ("Secure Connection", "Connexió segura"),
         ("Insecure Connection", "Connexió no segura"),
+        ("Continue", ""),
         ("Scale original", "Escala original"),
         ("Scale adaptive", "Escala adaptativa"),
         ("General", "General"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostra a la barra d’eines minimitzada"),
         ("All monitors", "Tots els monitors"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "No s'ha pogut verificar el xifratge d'extrem a extrem per a aquesta sessió.\nEl servidor RustDesk pot haver estat modificat, no ser de confiança o ser maliciós.\nEncara voleu continuar?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "中继连接"),
         ("Secure Connection", "安全连接"),
         ("Insecure Connection", "非安全连接"),
+        ("Continue", ""),
         ("Scale original", "原始尺寸"),
         ("Scale adaptive", "适应窗口"),
         ("General", "常规"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "在最小化工具栏上显示"),
         ("All monitors", "所有显示器"),
         ("#{} monitor", "{}号显示器"),
+        ("conn-e2ee-unavailable-tip", "无法验证此会话的端到端加密。\nRustDesk 服务器可能已被修改、不受信任或是恶意服务器。\n你仍然想继续吗？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Připojení předávací server"),
         ("Secure Connection", "Zabezpečené připojení"),
         ("Insecure Connection", "Nezabezpečené připojení"),
+        ("Continue", ""),
         ("Scale original", "Originální měřítko"),
         ("Scale adaptive", "Adaptivní měřítko"),
         ("General", "Obecné"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Zobrazit na minimalizovaném panelu nástrojů"),
         ("All monitors", "Všechny monitory"),
         ("#{} monitor", "Monitor č. {}"),
+        ("conn-e2ee-unavailable-tip", "U této relace se nepodařilo ověřit koncové šifrování.\nServer RustDesk může být upravený, nedůvěryhodný nebo škodlivý.\nOpravdu chcete pokračovat?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Viderestillingsforbindelse"),
         ("Secure Connection", "Sikker forbindelse"),
         ("Insecure Connection", "Usikker forbindelse"),
+        ("Continue", ""),
         ("Scale original", "Original skalering"),
         ("Scale adaptive", "Adaptiv skalering"),
         ("General", "Generelt"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Vis på den minimerede værktøjslinje"),
         ("All monitors", "Alle skærme"),
         ("#{} monitor", "Skærm {}"),
+        ("conn-e2ee-unavailable-tip", "End-to-end-kryptering kunne ikke bekræftes for denne session.\nRustDesk-serveren kan være ændret, utroværdig eller ondsindet.\nVil du stadig fortsætte?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relay-Verbindung"),
         ("Secure Connection", "Sichere Verbindung"),
         ("Insecure Connection", "Unsichere Verbindung"),
+        ("Continue", ""),
         ("Scale original", "Keine Skalierung"),
         ("Scale adaptive", "Anpassbare Skalierung"),
         ("General", "Allgemein"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "In der minimierten Symbolleiste anzeigen"),
         ("All monitors", "Alle Bildschirme"),
         ("#{} monitor", "Bildschirm {}"),
+        ("conn-e2ee-unavailable-tip", "Die Ende-zu-Ende-Verschlüsselung konnte für diese Sitzung nicht verifiziert werden.\nDer RustDesk-Server könnte verändert, nicht vertrauenswürdig oder bösartig sein.\nMöchten Sie trotzdem fortfahren?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Αναμεταδιδόμενη σύνδεση"),
         ("Secure Connection", "Ασφαλής σύνδεση"),
         ("Insecure Connection", "Μη ασφαλής σύνδεση"),
+        ("Continue", ""),
         ("Scale original", "Κλιμάκωση πρωτότυπου"),
         ("Scale adaptive", "Προσαρμοσμένη κλίμακα"),
         ("General", "Γενικά"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Εμφάνιση στην ελαχιστοποιημένη γραμμή εργαλείων"),
         ("All monitors", "Όλες οι οθόνες"),
         ("#{} monitor", "Οθόνη {}"),
+        ("conn-e2ee-unavailable-tip", "Δεν ήταν δυνατή η επαλήθευση της κρυπτογράφησης από άκρο σε άκρο για αυτήν τη συνεδρία.\nΟ διακομιστής RustDesk μπορεί να έχει τροποποιηθεί, να μην είναι αξιόπιστος ή να είναι κακόβουλος.\nΘέλετε ακόμα να συνεχίσετε;"),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -279,5 +279,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("wayland-soft-keyboard-input-label", "Soft keyboard input"),
         ("wayland-keyboard-input-reset-choice-tip", "Reset keyboard input choice"),
         ("remember-wayland-keyboard-choice-tip", "Don't ask again for this remote computer"),
+        ("conn-e2ee-unavailable-tip", "End-to-end encryption could not be verified for this session.\nThe RustDesk server may be modified, untrusted, or malicious.\nDo you still want to continue?")
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relajsa Konekto"),
         ("Secure Connection", "Sekura Konekto"),
         ("Insecure Connection", "Nesekura Konekto"),
+        ("Continue", ""),
         ("Scale original", "Skalo originalo"),
         ("Scale adaptive", "Skalo adapta"),
         ("General", "Ĝenerala"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Montri en la minimumigita ilobreto"),
         ("All monitors", "Ĉiuj monitoroj"),
         ("#{} monitor", "Monitoro {}"),
+        ("conn-e2ee-unavailable-tip", "Ne eblis kontroli la fin-al-finan ĉifradon por ĉi tiu seanco.\nLa RustDesk-servilo povas esti modifita, nefidinda aŭ malica.\nĈu vi ankoraŭ volas daŭrigi?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Conexión Relay"),
         ("Secure Connection", "Conexión segura"),
         ("Insecure Connection", "Conexión insegura"),
+        ("Continue", ""),
         ("Scale original", "Escala original"),
         ("Scale adaptive", "Escala adaptativa"),
         ("General", "General"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar en la barra de herramientas minimizada"),
         ("All monitors", "Todos los monitores"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "No se pudo verificar el cifrado de extremo a extremo para esta sesión.\nEl servidor RustDesk puede estar modificado, no ser de confianza o ser malicioso.\n¿Aún desea continuar?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Releeühendus"),
         ("Secure Connection", "Turvaline ühendus"),
         ("Insecure Connection", "Ebaturvaline ühendus"),
+        ("Continue", ""),
         ("Scale original", "Originaalskaala"),
         ("Scale adaptive", "Kohanduv skaala"),
         ("General", "Üldine"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Näita minimeeritud tööriistaribal"),
         ("All monitors", "Kõik kuvarid"),
         ("#{} monitor", "Kuvar {}"),
+        ("conn-e2ee-unavailable-tip", "Selle seansi otspunktkrüptimist ei saanud kontrollida.\nRustDesk server võib olla muudetud, ebausaldusväärne või pahatahtlik.\nKas soovite siiski jätkata?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Konexio igorria"),
         ("Secure Connection", "Konexio segurua"),
         ("Insecure Connection", "Konexio ez-segurua"),
+        ("Continue", ""),
         ("Scale original", "Jatorrizko eskala"),
         ("Scale adaptive", "Eskala moldagarria"),
         ("General", "Orokorra"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Erakutsi minimizatutako tresna-barran"),
         ("All monitors", "Monitore guztiak"),
         ("#{} monitor", "{}. monitorea"),
+        ("conn-e2ee-unavailable-tip", "Ezin izan da saio honen muturretik muturrerako enkriptatzea egiaztatu.\nRustDesk zerbitzaria aldatua, fidagaitza edo maltzurra izan daiteke.\nOraindik jarraitu nahi duzu?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relay ارتباط"),
         ("Secure Connection", "ارتباط امن"),
         ("Insecure Connection", "ارتباط غیر امن"),
+        ("Continue", ""),
         ("Scale original", "مقیاس اصلی"),
         ("Scale adaptive", "مقیاس تطبیقی"),
         ("General", "عمومی"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "نمایش در نوار ابزار کوچک‌شده"),
         ("All monitors", "همه نمایشگرها"),
         ("#{} monitor", "نمایشگر {}"),
+        ("conn-e2ee-unavailable-tip", "رمزنگاری سرتاسری برای این نشست قابل تأیید نیست.\nسرور RustDesk ممکن است تغییر یافته، نامطمئن یا مخرب باشد.\nآیا هنوز می‌خواهید ادامه دهید؟"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Välitetty yhteys"),
         ("Secure Connection", "Suojattu yhteys"),
         ("Insecure Connection", "Suojaamaton yhteys"),
+        ("Continue", ""),
         ("Scale original", "Skaalaa alkuperäinen"),
         ("Scale adaptive", "Mukautuva skaalaus"),
         ("General", "Yleiset"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Näytä pienennetyssä työkalurivissä"),
         ("All monitors", "Kaikki näytöt"),
         ("#{} monitor", "Näyttö {}"),
+        ("conn-e2ee-unavailable-tip", "Tämän istunnon päästä päähän -salausta ei voitu vahvistaa.\nRustDesk-palvelin voi olla muokattu, epäluotettava tai haitallinen.\nHaluatko silti jatkaa?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Connexion via relais"),
         ("Secure Connection", "Connexion sécurisée"),
         ("Insecure Connection", "Connexion non sécurisée"),
+        ("Continue", ""),
         ("Scale original", "Échelle originale"),
         ("Scale adaptive", "Échelle adaptative"),
         ("General", "Général"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Afficher dans la barre d’outils réduite"),
         ("All monitors", "Tous les moniteurs"),
         ("#{} monitor", "Moniteur {}"),
+        ("conn-e2ee-unavailable-tip", "Le chiffrement de bout en bout n'a pas pu être vérifié pour cette session.\nLe serveur RustDesk peut être modifié, non fiable ou malveillant.\nVoulez-vous toujours continuer ?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "რეტრანსლირებული კავშირი"),
         ("Secure Connection", "უსაფრთხო კავშირი"),
         ("Insecure Connection", "არაუსაფრთხო კავშირი"),
+        ("Continue", ""),
         ("Scale original", "ორიგინალური მასშტაბი"),
         ("Scale adaptive", "ადაპტირებადი მასშტაბი"),
         ("General", "ზოგადი"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ჩვენება ჩაკეცილ ხელსაწყოთა ზოლზე"),
         ("All monitors", "ყველა მონიტორი"),
         ("#{} monitor", "მონიტორი {}"),
+        ("conn-e2ee-unavailable-tip", "ამ სესიისთვის ბოლომდე დაშიფვრის გადამოწმება ვერ მოხერხდა.\nRustDesk სერვერი შეიძლება შეცვლილი, არასანდო ან მავნე იყოს.\nმაინც გსურთ გაგრძელება?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "રિલે કનેક્શન"),
         ("Secure Connection", "સુરક્ષિત કનેક્શન"),
         ("Insecure Connection", "અસુરક્ષિત કનેક્શન"),
+        ("Continue", ""),
         ("Scale original", "મૂળ સ્કેલ"),
         ("Scale adaptive", "એડેપ્ટિવ સ્કેલ"),
         ("General", "સામાન્ય"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ન્યૂનતમ કરેલા ટૂલબાર પર બતાવો"),
         ("All monitors", "બધા મોનિટર"),
         ("#{} monitor", "મોનિટર {}"),
+        ("conn-e2ee-unavailable-tip", "આ સત્ર માટે એન્ડ-ટુ-એન્ડ એન્ક્રિપ્શનની ચકાસણી કરી શકાઈ નથી.\nRustDesk સર્વર બદલાયેલું, અવિશ્વસનીય અથવા દુર્ભાવનાપૂર્ણ હોઈ શકે છે.\nશું તમે હજુ પણ ચાલુ રાખવા માંગો છો?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "חיבור באמצעות ממסר"),
         ("Secure Connection", "חיבור מאובטח"),
         ("Insecure Connection", "חיבור לא מאובטח"),
+        ("Continue", ""),
         ("Scale original", "קנה מידה מקורי"),
         ("Scale adaptive", "קנה מידה מותאם"),
         ("General", "כללי"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "הצגה בסרגל הכלים הממוזער"),
         ("All monitors", "כל המסכים"),
         ("#{} monitor", "מסך {}"),
+        ("conn-e2ee-unavailable-tip", "לא ניתן היה לאמת את ההצפנה מקצה לקצה עבור הפעלה זו.\nשרת RustDesk עשוי להיות שונה, לא מהימן או זדוני.\nהאם עדיין ברצונך להמשיך?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "रिले कनेक्शन"),
         ("Secure Connection", "सुरक्षित कनेक्शन"),
         ("Insecure Connection", "असुरक्षित कनेक्शन"),
+        ("Continue", ""),
         ("Scale original", "मूल पैमाना"),
         ("Scale adaptive", "अनुकूली पैमाना"),
         ("General", "सामान्य"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "न्यूनतम किए गए टूलबार पर दिखाएं"),
         ("All monitors", "सभी मॉनिटर"),
         ("#{} monitor", "मॉनिटर {}"),
+        ("conn-e2ee-unavailable-tip", "इस सत्र के लिए एंड-टू-एंड एन्क्रिप्शन सत्यापित नहीं किया जा सका।\nRustDesk सर्वर संशोधित, अविश्वसनीय या दुर्भावनापूर्ण हो सकता है।\nक्या आप अभी भी जारी रखना चाहते हैं?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Posredna veza"),
         ("Secure Connection", "Sigurna veza"),
         ("Insecure Connection", "Nesigurna veza"),
+        ("Continue", ""),
         ("Scale original", "Skaliraj izvornik"),
         ("Scale adaptive", "Prilagođeno skaliranje"),
         ("General", "Općenito"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Prikaži na minimiziranoj alatnoj traci"),
         ("All monitors", "Svi monitori"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "End-to-end enkripcija nije mogla biti potvrđena za ovu sesiju.\nRustDesk poslužitelj može biti izmijenjen, nepouzdan ili zlonamjeran.\nŽelite li ipak nastaviti?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Kapcsolódás továbbító-kiszolgálón keresztül"),
         ("Secure Connection", "Biztonságos kapcsolat"),
         ("Insecure Connection", "Nem biztonságos kapcsolat"),
+        ("Continue", ""),
         ("Scale original", "Eredeti méretarány"),
         ("Scale adaptive", "Adaptív méretarány"),
         ("General", "Általános"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Megjelenítés a kis méretű eszköztáron"),
         ("All monitors", "Minden monitor"),
         ("#{} monitor", "{}. monitor"),
+        ("conn-e2ee-unavailable-tip", "A végpontok közötti titkosítás nem volt ellenőrizhető ehhez a munkamenethez.\nA RustDesk szerver módosított, nem megbízható vagy rosszindulatú lehet.\nBiztosan folytatja?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Koneksi Relay"),
         ("Secure Connection", "Koneksi aman"),
         ("Insecure Connection", "Koneksi Tidak Aman"),
+        ("Continue", ""),
         ("Scale original", "Skala asli"),
         ("Scale adaptive", "Skala adaptif"),
         ("General", "Umum"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Tampilkan di bilah alat yang diperkecil"),
         ("All monitors", "Semua monitor"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "Enkripsi ujung ke ujung tidak dapat diverifikasi untuk sesi ini.\nServer RustDesk mungkin telah dimodifikasi, tidak tepercaya, atau berbahaya.\nApakah Anda masih ingin melanjutkan?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Connessione relay"),
         ("Secure Connection", "Connessione sicura"),
         ("Insecure Connection", "Connessione non sicura"),
+        ("Continue", ""),
         ("Scale original", "Scala originale"),
         ("Scale adaptive", "Scala adattiva"),
         ("General", "Generale"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Visualizza nella barra strumenti ridotta a icona"),
         ("All monitors", "Tutti gli schermi"),
         ("#{} monitor", "Schermo {}"),
+        ("conn-e2ee-unavailable-tip", "Non è stato possibile verificare la crittografia end-to-end per questa sessione.\nIl server RustDesk potrebbe essere modificato, non attendibile o dannoso.\nVuoi comunque continuare?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "中継接続"),
         ("Secure Connection", "安全な接続"),
         ("Insecure Connection", "安全でない接続"),
+        ("Continue", ""),
         ("Scale original", "オリジナルのサイズ"),
         ("Scale adaptive", "ウィンドウに合わせる"),
         ("General", "一般"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "最小化したツールバーに表示"),
         ("All monitors", "すべてのディスプレイ"),
         ("#{} monitor", "ディスプレイ {}"),
+        ("conn-e2ee-unavailable-tip", "このセッションのエンドツーエンド暗号化を確認できませんでした。\nRustDesk サーバーは変更されている、信頼できない、または悪意がある可能性があります。\nそれでも続行しますか？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "릴레이 연결"),
         ("Secure Connection", "보안 연결"),
         ("Insecure Connection", "보안되지 않은 연결"),
+        ("Continue", ""),
         ("Scale original", "원본 크기 조정"),
         ("Scale adaptive", "크기 조정 가능"),
         ("General", "일반"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "최소화된 도구 모음에 표시"),
         ("All monitors", "모든 모니터"),
         ("#{} monitor", "#{} 모니터"),
+        ("conn-e2ee-unavailable-tip", "이 세션의 종단 간 암호화를 확인할 수 없습니다.\nRustDesk 서버가 수정되었거나 신뢰할 수 없거나 악의적일 수 있습니다.\n그래도 계속하시겠습니까?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Релай Қосылым"),
         ("Secure Connection", "Қауіпсіз Қосылым"),
         ("Insecure Connection", "Қатерлі Қосылым"),
+        ("Continue", ""),
         ("Scale original", "Scale original"),
         ("Scale adaptive", "Scale adaptive"),
         ("General", "Жалпы"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Кішірейтілген құралдар тақтасында көрсету"),
         ("All monitors", "Барлық мониторлар"),
         ("#{} monitor", "Монитор {}"),
+        ("conn-e2ee-unavailable-tip", "Бұл сеанс үшін ұштан-ұшқа шифрлауды тексеру мүмкін болмады.\nRustDesk сервері өзгертілген, сенімсіз немесе зиянды болуы мүмкін.\nСонда да жалғастырғыңыз келе ме?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Tarpinė jungtis"),
         ("Secure Connection", "Saugus ryšys"),
         ("Insecure Connection", "Nesaugus ryšys"),
+        ("Continue", ""),
         ("Scale original", "Pakeisti originalų mastelį"),
         ("Scale adaptive", "Pritaikomas mastelis"),
         ("General", "Bendra"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Rodyti sumažintoje įrankių juostoje"),
         ("All monitors", "Visi monitoriai"),
         ("#{} monitor", "Monitorius {}"),
+        ("conn-e2ee-unavailable-tip", "Šios sesijos galinio šifravimo nepavyko patikrinti.\nRustDesk serveris gali būti pakeistas, nepatikimas arba kenkėjiškas.\nAr vis tiek norite tęsti?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Releja savienojums"),
         ("Secure Connection", "Drošs savienojums"),
         ("Insecure Connection", "Nedrošs savienojums"),
+        ("Continue", ""),
         ("Scale original", "Mērogs oriģināls"),
         ("Scale adaptive", "Mērogs adaptīvs"),
         ("General", "Vispārīgi"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Rādīt minimizētajā rīkjoslā"),
         ("All monitors", "Visi monitori"),
         ("#{} monitor", "Monitors {}"),
+        ("conn-e2ee-unavailable-tip", "Šai sesijai neizdevās pārbaudīt pilnīgu šifrēšanu.\nRustDesk serveris var būt modificēts, neuzticams vai ļaunprātīgs.\nVai joprojām vēlaties turpināt?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "റിലേ കണക്ഷൻ"),
         ("Secure Connection", "സുരക്ഷിതമായ കണക്ഷൻ"),
         ("Insecure Connection", "സുരക്ഷിതമല്ലാത്ത കണക്ഷൻ"),
+        ("Continue", ""),
         ("Scale original", "ഒറിജിനൽ വലിപ്പം"),
         ("Scale adaptive", "അഡാപ്റ്റീവ് വലിപ്പം"),
         ("General", "പൊതുവായവ"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ചെറുതാക്കിയ ടൂൾബാറിൽ കാണിക്കുക"),
         ("All monitors", "എല്ലാ മോണിറ്ററുകളും"),
         ("#{} monitor", "മോണിറ്റർ {}"),
+        ("conn-e2ee-unavailable-tip", "ഈ സെഷനിലെ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ പരിശോധിക്കാൻ കഴിഞ്ഞില്ല.\nRustDesk സർവർ മാറ്റം വരുത്തിയതോ വിശ്വസനീയമല്ലാത്തതോ ദോഷകരമായതോ ആയിരിക്കാം.\nനിങ്ങൾക്ക് ഇപ്പോഴും തുടരണമോ?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Viderekoblet tilkobling"),
         ("Secure Connection", "Sikker tilkobling"),
         ("Insecure Connection", "Usikker tilkobling"),
+        ("Continue", ""),
         ("Scale original", "Original skalering"),
         ("Scale adaptive", "Adaptiv skalering"),
         ("General", "Generelt"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Vis på den minimerte verktøylinjen"),
         ("All monitors", "Alle skjermer"),
         ("#{} monitor", "Skjerm {}"),
+        ("conn-e2ee-unavailable-tip", "Ende-til-ende-kryptering kunne ikke verifiseres for denne økten.\nRustDesk-serveren kan være endret, upålitelig eller skadelig.\nVil du fortsatt fortsette?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relaisverbinding"),
         ("Secure Connection", "Beveiligde Verbinding"),
         ("Insecure Connection", "Onveilige Verbinding"),
+        ("Continue", ""),
         ("Scale original", "Oorspronkelijk formaat"),
         ("Scale adaptive", "Automatisch schalen"),
         ("General", "Algemeen"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Weergeven op de geminimaliseerde werkbalk"),
         ("All monitors", "Alle monitoren"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "End-to-endversleuteling kon niet worden geverifieerd voor deze sessie.\nDe RustDesk-server kan gewijzigd, niet vertrouwd of kwaadaardig zijn.\nWilt u toch doorgaan?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Połączenie przez bramkę"),
         ("Secure Connection", "Połączenie szyfrowane"),
         ("Insecure Connection", "Połączenie nieszyfrowane"),
+        ("Continue", ""),
         ("Scale original", "Skalowanie oryginalne"),
         ("Scale adaptive", "Dopasuj do wyświetlacza"),
         ("General", "Ogólne"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Pokaż na zminimalizowanym pasku narzędzi"),
         ("All monitors", "Wszystkie ekrany"),
         ("#{} monitor", "Ekran {}"),
+        ("conn-e2ee-unavailable-tip", "Nie można zweryfikować szyfrowania end-to-end dla tej sesji.\nSerwer RustDesk może być zmodyfikowany, niezaufany lub złośliwy.\nCzy nadal chcesz kontynuować?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Conexão de relé"),
         ("Secure Connection", "Conexão segura"),
         ("Insecure Connection", "Conexão insegura"),
+        ("Continue", ""),
         ("Scale original", "Escala original"),
         ("Scale adaptive", "Escala adaptável"),
         ("General", "Geral"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar na barra de ferramentas minimizada"),
         ("All monitors", "Todos os monitores"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "Não foi possível verificar a encriptação de ponta a ponta para esta sessão.\nO servidor RustDesk pode ter sido modificado, não ser fidedigno ou ser malicioso.\nAinda pretende continuar?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Conexão via Relay"),
         ("Secure Connection", "Conexão Segura"),
         ("Insecure Connection", "Conexão Insegura"),
+        ("Continue", ""),
         ("Scale original", "Escala original"),
         ("Scale adaptive", "Escala adaptada"),
         ("General", "Geral"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar na barra de ferramentas minimizada"),
         ("All monitors", "Todas as telas"),
         ("#{} monitor", "Tela {}"),
+        ("conn-e2ee-unavailable-tip", "Não foi possível verificar a criptografia de ponta a ponta desta sessão.\nO servidor RustDesk pode ter sido modificado, não ser confiável ou ser malicioso.\nVocê ainda deseja continuar?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Conexiune prin retransmisie"),
         ("Secure Connection", "Conexiune securizată"),
         ("Insecure Connection", "Conexiune nesecurizată"),
+        ("Continue", ""),
         ("Scale original", "Dimensiune originală"),
         ("Scale adaptive", "Scalare automată"),
         ("General", "General"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Afișează în bara de instrumente minimizată"),
         ("All monitors", "Toate monitoarele"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "Criptarea end-to-end nu a putut fi verificată pentru această sesiune.\nServerul RustDesk poate fi modificat, nefiabil sau rău intenționat.\nDoriți totuși să continuați?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Ретранслируемое подключение"),
         ("Secure Connection", "Безопасное подключение"),
         ("Insecure Connection", "Небезопасное подключение"),
+        ("Continue", ""),
         ("Scale original", "Оригинальный масштаб"),
         ("Scale adaptive", "Адаптивный масштаб"),
         ("General", "Общие"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показывать на свёрнутой панели инструментов"),
         ("All monitors", "Все мониторы"),
         ("#{} monitor", "Монитор {}"),
+        ("conn-e2ee-unavailable-tip", "Не удалось проверить сквозное шифрование для этого сеанса.\nСервер RustDesk может быть изменен, ненадежен или вредоносен.\nВы все равно хотите продолжить?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Connessione tramudada (relay)"),
         ("Secure Connection", "Connessione segura"),
         ("Insecure Connection", "Connessione non segura"),
+        ("Continue", ""),
         ("Scale original", "Iscala originale"),
         ("Scale adaptive", "Iscala adativa"),
         ("General", "Generale"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mustra in sa barra de aina minimizada"),
         ("All monitors", "Totu sos ischermos"),
         ("#{} monitor", "Ischermu {}"),
+        ("conn-e2ee-unavailable-tip", "No est istadu possìbile verificare sa tzifratzione de punta a punta pro custa sessione.\nSu server RustDesk podet èssere modificadu, non fidadu o malitziosu.\nBoles sighire ancora?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Reléové pripojenie"),
         ("Secure Connection", "Zabezpečené pripojenie"),
         ("Insecure Connection", "Nezabezpečené pripojenie"),
+        ("Continue", ""),
         ("Scale original", "Pôvodná mierka"),
         ("Scale adaptive", "Prispôsobivá mierka"),
         ("General", "Všeobecné"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Zobraziť na minimalizovanom paneli nástrojov"),
         ("All monitors", "Všetky monitory"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "Pre túto reláciu nebolo možné overiť koncové šifrovanie.\nServer RustDesk môže byť upravený, nedôveryhodný alebo škodlivý.\nChcete napriek tomu pokračovať?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Posredovana povezava"),
         ("Secure Connection", "Zavarovana povezava"),
         ("Insecure Connection", "Nezavarovana povezava"),
+        ("Continue", ""),
         ("Scale original", "Originalna velikost"),
         ("Scale adaptive", "Prilagojena velikost"),
         ("General", "Splošno"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Pokaži v pomanjšani orodni vrstici"),
         ("All monitors", "Vsi zasloni"),
         ("#{} monitor", "Zaslon {}"),
+        ("conn-e2ee-unavailable-tip", "Šifriranja od konca do konca za to sejo ni bilo mogoče preveriti.\nStrežnik RustDesk je lahko spremenjen, nezaupanja vreden ali zlonameren.\nAli še vedno želite nadaljevati?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Lidhja rele"),
         ("Secure Connection", "Lidhje e sigurt"),
         ("Insecure Connection", "Lidhje e pasigurt"),
+        ("Continue", ""),
         ("Scale original", "Shkalla origjinale"),
         ("Scale adaptive", " E përsjhtatshme në shkallë"),
         ("General", "Gjeneral"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Shfaq te shiriti i minimizuar i veglave"),
         ("All monitors", "Të gjithë monitorët"),
         ("#{} monitor", "Monitori {}"),
+        ("conn-e2ee-unavailable-tip", "Enkriptimi nga skaji në skaj nuk mund të verifikohej për këtë seancë.\nServeri RustDesk mund të jetë i modifikuar, i pabesueshëm ose keqdashës.\nDëshironi të vazhdoni gjithsesi?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Posredna konekcija"),
         ("Secure Connection", "Bezbedna konekcija"),
         ("Insecure Connection", "Nebezbedna konekcija"),
+        ("Continue", ""),
         ("Scale original", "Skaliraj original"),
         ("Scale adaptive", "Adaptivno skaliranje"),
         ("General", "Uopšteno"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Прикажи на умањеној траци са алаткама"),
         ("All monitors", "Svi monitori"),
         ("#{} monitor", "Monitor {}"),
+        ("conn-e2ee-unavailable-tip", "Енд-то-енд шифровање није могло бити проверено за ову сесију.\nRustDesk сервер може бити измењен, непоуздан или злонамеран.\nДа ли и даље желите да наставите?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relayanslutning"),
         ("Secure Connection", "Säker anslutning"),
         ("Insecure Connection", "Osäker anslutning"),
+        ("Continue", ""),
         ("Scale original", "Skala orginal"),
         ("Scale adaptive", "Skala adaptivt"),
         ("General", "Generellt"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Visa i det minimerade verktygsfältet"),
         ("All monitors", "Alla skärmar"),
         ("#{} monitor", "Skärm {}"),
+        ("conn-e2ee-unavailable-tip", "End-to-end-kryptering kunde inte verifieras för den här sessionen.\nRustDesk-servern kan vara ändrad, opålitlig eller skadlig.\nVill du ändå fortsätta?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "ரிலே இணைப்பு"),
         ("Secure Connection", "பாதுகாப்பான இணைப்பு"),
         ("Insecure Connection", "பாதுகாப்பற்ற இணைப்பு"),
+        ("Continue", ""),
         ("Scale original", "அசல் அளவு"),
         ("Scale adaptive", "தகவமைப்பு அளவு"),
         ("General", "பொது"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "சிறிதாக்கப்பட்ட கருவிப்பட்டையில் காட்டு"),
         ("All monitors", "அனைத்து மானிட்டர்களும்"),
         ("#{} monitor", "மானிட்டர் {}"),
+        ("conn-e2ee-unavailable-tip", "இந்த அமர்விற்கான முடிவு-முதல்-முடிவு குறியாக்கத்தை சரிபார்க்க முடியவில்லை.\nRustDesk சேவையகம் மாற்றப்பட்டதாக, நம்பகமற்றதாக அல்லது தீங்கிழைப்பதாக இருக்கலாம்.\nநீங்கள் இன்னும் தொடர விரும்புகிறீர்களா?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", ""),
         ("Secure Connection", ""),
         ("Insecure Connection", ""),
+        ("Continue", ""),
         ("Scale original", ""),
         ("Scale adaptive", ""),
         ("General", ""),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", ""),
         ("All monitors", ""),
         ("#{} monitor", ""),
+        ("conn-e2ee-unavailable-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "การเชื่อมต่อแบบ Relay "),
         ("Secure Connection", "การเชื่อมต่อที่ปลอดภัย"),
         ("Insecure Connection", "การเชื่อมต่อที่ไม่ปลอดภัย"),
+        ("Continue", ""),
         ("Scale original", "ขนาดเดิม"),
         ("Scale adaptive", "ขนาดยืดหยุ่น"),
         ("General", "ทั่วไป"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "แสดงบนแถบเครื่องมือที่ย่อเล็กสุด"),
         ("All monitors", "จอภาพทั้งหมด"),
         ("#{} monitor", "จอภาพ {}"),
+        ("conn-e2ee-unavailable-tip", "ไม่สามารถยืนยันการเข้ารหัสแบบต้นทางถึงปลายทางสำหรับเซสชันนี้ได้\nเซิร์ฟเวอร์ RustDesk อาจถูกดัดแปลง ไม่น่าเชื่อถือ หรือเป็นอันตราย\nคุณยังต้องการดำเนินการต่อหรือไม่?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Aktarmalı Bağlantı"),
         ("Secure Connection", "Güvenli Bağlantı"),
         ("Insecure Connection", "Güvenli Olmayan Bağlantı"),
+        ("Continue", ""),
         ("Scale original", "Orijinal ölçekte"),
         ("Scale adaptive", "Uyarlanabilir ölçekte"),
         ("General", "Genel"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Simge durumuna küçültülmüş araç çubuğunda göster"),
         ("All monitors", "Tüm monitörler"),
         ("#{} monitor", "Monitör {}"),
+        ("conn-e2ee-unavailable-tip", "Bu oturum için uçtan uca şifreleme doğrulanamadı.\nRustDesk sunucusu değiştirilmiş, güvenilmeyen veya kötü amaçlı olabilir.\nYine de devam etmek istiyor musunuz?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "中繼連線"),
         ("Secure Connection", "安全連線"),
         ("Insecure Connection", "非安全連線"),
+        ("Continue", ""),
         ("Scale original", "原始尺寸"),
         ("Scale adaptive", "適應視窗"),
         ("General", "一般"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "在最小化工具列上顯示"),
         ("All monitors", "所有顯示器"),
         ("#{} monitor", "{}號顯示器"),
+        ("conn-e2ee-unavailable-tip", "無法驗證此工作階段的端對端加密。\nRustDesk 伺服器可能已被修改、不受信任或具有惡意。\n您仍要繼續嗎？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Ретрансльоване підключення"),
         ("Secure Connection", "Безпечне підключення"),
         ("Insecure Connection", "Небезпечне підключення"),
+        ("Continue", ""),
         ("Scale original", "Оригінальний масштаб"),
         ("Scale adaptive", "Адаптивний масштаб"),
         ("General", "Загальні"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показувати на згорнутій панелі інструментів"),
         ("All monitors", "Усі монітори"),
         ("#{} monitor", "Монітор {}"),
+        ("conn-e2ee-unavailable-tip", "Не вдалося перевірити наскрізне шифрування для цього сеансу.\nСервер RustDesk може бути змінений, ненадійний або шкідливий.\nВи все одно хочете продовжити?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -332,6 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Kết nối chuyển tiếp"),
         ("Secure Connection", "Kết nối bảo mật"),
         ("Insecure Connection", "Kết nối không bảo mật"),
+        ("Continue", ""),
         ("Scale original", "Tỷ lệ gốc"),
         ("Scale adaptive", "Tỷ lệ thích ứng"),
         ("General", "Chung"),
@@ -763,5 +764,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Hiển thị trên thanh công cụ thu nhỏ"),
         ("All monitors", "Tất cả màn hình"),
         ("#{} monitor", "Màn hình {}"),
+        ("conn-e2ee-unavailable-tip", "Không thể xác minh mã hóa đầu cuối cho phiên này.\nMáy chủ RustDesk có thể đã bị sửa đổi, không đáng tin cậy hoặc độc hại.\nBạn vẫn muốn tiếp tục chứ?"),
     ].iter().cloned().collect();
 }

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -296,6 +296,14 @@ function msgbox(type, title, content, link="", callback=null, height=180, width=
               else msgbox("connecting", "Connecting...", "Logging in...");
             }
         };
+    } else if (type.indexOf("insecure-connection") >= 0) {
+        callback = function (res) {
+            if (!res) {
+                view.close();
+                return;
+            }
+            handler.continue_insecure_connection();
+        };
     } else if (type.indexOf("custom") < 0 && !is_port_forward && !callback) {
         callback = function() { view.close(); }
     } else if (type == 'wait-remote-accept-nook') {

--- a/src/ui/msgbox.tis
+++ b/src/ui/msgbox.tis
@@ -152,6 +152,7 @@ class MsgboxComponent: Reactor.Component {
         var hasOk = this.type != "connecting" && this.type != "success" && this.type.indexOf("nook") < 0;
         var hasLink = this.link != "";
         var hasClose = this.type.indexOf("hasclose") >= 0;
+        var isInsecureConnection = this.type.indexOf("insecure-connection") >= 0;
         var show_progress = this.type == "connecting";
         var me = this;
         self.timer(0, msgboxTimerFunc);
@@ -176,11 +177,12 @@ class MsgboxComponent: Reactor.Component {
                 <div style="text-align: right;">
                     <span style="display:inline-block; max-width: 250px; font-size:12px;" #error />
                     <progress #progress style={"color:" + color + "; display: " + (show_progress ? "inline-block" : "none")} />
+                    {isInsecureConnection && hasOk ? <button .button #submit .outline>{translate('Continue')}</button> : ""}
                     {hasCancel || this.hasRetry ? <button .button #cancel .outline>{translate(this.hasRetry ? "OK" : "Cancel")}</button> : ""}
                     {this.hasSkip() ? <button .button #skip .outline>{translate('Skip')}</button> : ""}
-                    {hasOk || this.hasRetry ? <button .button #submit>{translate(this.hasRetry ? "Retry" : "OK")}</button> : ""}
+                    {!isInsecureConnection && (hasOk || this.hasRetry) ? <button .button #submit>{translate(this.hasRetry ? "Retry" : "OK")}</button> : ""}
                     {hasLink ? <button .button #jumplink .outline>{translate('JumpLink')}</button> : ""}
-                    {hasClose ? <button .button #cancel .outline>{translate('Close')}</button> : ""}
+                    {hasClose ? (isInsecureConnection ? <button .button #cancel>{translate('Disconnect')}</button> : <button .button #cancel .outline>{translate('Close')}</button>) : ""}
                     {this.getScreenshotButtons()}
                 </div>
             </div>
@@ -193,6 +195,10 @@ class MsgboxComponent: Reactor.Component {
     }
     
     function submit() {
+        if (this.type.indexOf("insecure-connection") >= 0) {
+            this.cancel();
+            return;
+        }
         var submit_btn = this.$(button#submit);
         if (submit_btn) {
             if (submit_btn.state.disabled) return;
@@ -376,7 +382,11 @@ class MsgboxComponent: Reactor.Component {
             var el = me.$(.outline-focus);
             if (el) view.focus = el;
             else {
-                el = me.$(#submit);
+                if (me.type.indexOf("insecure-connection") >= 0) {
+                    el = me.$(#cancel);
+                } else {
+                    el = me.$(#submit);
+                }
                 if (el) {
                     view.focus = el;
                 }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -513,6 +513,7 @@ impl sciter::EventHandler for SciterSession {
         fn is_rdp();
         fn login(String, String, String, bool);
         fn send2fa(String, bool);
+        fn continue_insecure_connection();
         fn get_enable_trusted_devices();
         fn new_rdp();
         fn send_mouse(i32, i32, i32, bool, bool, bool, bool);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -52,6 +52,7 @@ use crate::keyboard;
 use crate::{client::Data, client::Interface};
 
 const CHANGE_RESOLUTION_VALID_TIMEOUT_SECS: u64 = 15;
+pub const INSECURE_CONNECTION_CONFIRM_OPTION: &str = "insecure-connection-confirmed";
 
 #[derive(Clone, Default)]
 pub struct Session<T: InvokeUiSession> {
@@ -1406,6 +1407,10 @@ impl<T: InvokeUiSession> Session<T> {
 
     pub fn close(&self) {
         self.send(Data::Close);
+    }
+
+    pub fn continue_insecure_connection(&self) {
+        self.send(Data::ContinueInsecureConnection);
     }
 
     fn try_auto_start_job_str(is_reconnected: bool, job_str: &str) -> Option<String> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an insecure-connection confirmation flow with **Continue** and **Disconnect** options.
  * Continuing now resumes the session after confirmation; disconnecting immediately terminates it.
  * Added new localized UI text (e.g., the “Continue” label and an “E2EE unavailable” warning) across many languages.
* **Bug Fixes**
  * Improved handling for non-secured peers: denial now stops the connection flow earlier and performs consistent disconnect cleanup.
  * Refined disconnect/close-reason timing behavior for more reliable session shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->